### PR TITLE
Document Android Studio setup workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🐺 Loup-Garous GM Assistant
 
-A **Game Master (DM) assistant** for Loup-Garous / Werewolf, built as a **React PWA** that runs in any browser and can be installed as a native app on Android via the Play Store (using a PWA wrapper like Bubblewrap/TWA).
+A **Game Master (DM) assistant** for Loup-Garous / Werewolf, built as a **React app** with an existing **Capacitor Android wrapper**. The web app remains the source of truth, and the `android/` folder is the Android Studio project used to run the app on a device or emulator.
 
 ---
 
@@ -25,6 +25,7 @@ A **Game Master (DM) assistant** for Loup-Garous / Werewolf, built as a **React 
 | **Role reference** | Filterable by Night / Day; shows all actions and triggers |
 | **Game log** | Chronological event history |
 | **Optional rules** | Per-game toggles for Elder, Scapegoat, etc. |
+| **Android wrapper** | Existing Capacitor project opens directly in Android Studio |
 | **PWA** | Installable on Android and iOS via the browser's "Add to Home Screen" prompt |
 | **Persistent state** | Game state saved to localStorage, survives page reload |
 
@@ -56,15 +57,43 @@ npm run test:e2e
 
 The test spins up the Vite dev server, runs a 6-player (2 wolves, 4 villagers) round, verifies roles display, phases transition, and captures artifacts if a crash/black screen occurs.
 
-## 📱 Android / Play Store
+## 📱 Android Studio Workflow
 
-This app ships a **Web App Manifest** (`public/manifest.json`), making it a PWA.
+This repository already includes the Android Studio project in `android/`. Do not create a second native app for local development.
 
-To publish on Google Play:
+### First-time setup
 
-1. Build the app: `npm run build`
-2. Use **[Bubblewrap](https://github.com/GoogleChromeLabs/bubblewrap)** or **[PWA Builder](https://www.pwabuilder.com/)** to wrap the hosted URL as a Trusted Web Activity (TWA).
-3. Upload the generated `.aab` to the Play Console.
+```bash
+npm install
+npm run cap:sync
+```
+
+`npm run cap:sync` builds the web app into `dist/` and copies those assets into the Capacitor Android project.
+
+### Open in Android Studio
+
+1. Open the `android/` folder in Android Studio.
+2. Let Gradle sync complete.
+3. If Android Studio asks for an SDK path, let it create `android/local.properties` or point it to your installed Android SDK.
+4. Select an emulator or device and press Run.
+
+### After web changes
+
+Whenever you change the React app:
+
+```bash
+npm run cap:sync
+```
+
+Then run the app again from Android Studio. The Android shell loads built files from `dist/`; it does not use the Vite dev server.
+
+### Notes
+
+- Android Studio project root: `android/`
+- Local SDK config file: `android/local.properties` (local only, not committed)
+- Capacitor config: `capacitor.config.ts`
+- Android package id: `com.panacota96.loupgarous`
+- More detail: [`docs/android-setup.md`](./docs/android-setup.md)
 
 ---
 

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,17 @@
+# Android Studio project
+
+Open this `android/` folder directly in Android Studio.
+
+Typical local workflow from the repository root:
+
+```bash
+npm install
+npm run cap:sync
+```
+
+Then return to Android Studio and run the app on an emulator or device.
+
+Notes:
+- The Android app loads built assets from `dist/`.
+- `local.properties` is local-only and should not be committed.
+- If Android Studio prompts for the Android SDK path, let it create `local.properties`.

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -3,6 +3,7 @@ import type { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   appId: 'com.panacota96.loupgarous',
   appName: 'loupgarous',
+  // Capacitor copies built web assets from dist/ into android/app/src/main/assets/public.
   webDir: 'dist'
 };
 

--- a/docs/android-setup.md
+++ b/docs/android-setup.md
@@ -1,37 +1,53 @@
-# Android testing with Capacitor
+# Android Studio setup with Capacitor
 
-This project is wrapped with Capacitor so you can build and run it in Android Studio.
+This project already includes a Capacitor Android wrapper. The web app remains the source of truth, and the `android/` folder is the Android Studio project root.
 
 ## Prerequisites
 - Node 18+ and npm installed
 - Android Studio with Android SDK + an emulator or a USB‑debuggable device
+- JDK 21 available to Android Studio / Gradle
 
 ## One-time setup
-1) Install deps and build web assets
+1) Install dependencies
 ```bash
 npm install
-npm run build
 ```
 
-2) Sync Capacitor + Android project (copies `dist/` into the Android app)
+2) Build and sync the Android wrapper
 ```bash
 npm run cap:sync
 ```
 
+This command does two things:
+- builds the web app into `dist/`
+- copies the built files into `android/app/src/main/assets/public`
+
 ## Open and run in Android Studio
-1) Open the generated Android project: `npm run cap:open:android`
+1) Open the existing Android Studio project in the `android/` folder.
 2) Let Gradle sync. If prompted, install missing SDK components.
-3) Pick an emulator or a plugged-in device in the Studio toolbar.
-4) Press Run ▶️. Android Studio will build and install the app.
+3) If the SDK path is missing, let Android Studio create `android/local.properties`, or create it yourself with:
+```properties
+sdk.dir=C:\\Users\\YOUR_USER\\AppData\\Local\\Android\\Sdk
+```
+4) Pick an emulator or a plugged-in device in the Studio toolbar.
+5) Press Run. Android Studio will build and install the app.
 
 ## Rebuild after web changes
 Any time you change the web app:
 ```bash
-npm run build
 npm run cap:sync
 ```
 Then re-run from Android Studio.
 
+The Android app consumes built files from `dist/`. It does not run against `npm run dev`.
+
 ## Notes
 - App id: `com.panacota96.loupgarous`
+- Android Studio project root: `android/`
 - Web assets folder: `dist/` (managed by Vite build)
+- Local SDK configuration file: `android/local.properties`
+- `android/local.properties` is local-only and should not be committed
+- Helpful scripts:
+  - `npm run build`
+  - `npm run cap:sync`
+  - `npm run cap:open:android`


### PR DESCRIPTION
## Summary
- document the existing Capacitor-based Android Studio workflow
- clarify that ndroid/ is the Android Studio project root and dist/ is the asset source
- add Android-specific setup notes for SDK configuration and rebuild/sync flow

## Verification
- npm run build
- npm run cap:sync
- npm run test:e2e
- android\\gradlew.bat assembleDebug
