### PR TITLE
[codex] Add protector night markers and lover override

### DIFF
--- a/src/components/Game/NightPhase.tsx
+++ b/src/components/Game/NightPhase.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { useGameStore } from '../../store/gameStore';
+import { resolveNightEliminations, useGameStore } from '../../store/gameStore';
 import { ROLE_MAP, WOLF_ROLE_IDS } from '../../data/roles';
 import '../../styles/night.css';
 
@@ -15,6 +15,9 @@ export default function NightPhase() {
   const wolfVictimId = useGameStore((s) => s.wolfVictimId);
   const wolfDogChoiceStore = useGameStore((s) => s.wolfDogChoice);
   const wildChildTransformed = useGameStore((s) => s.wildChildTransformed);
+  const protectedPlayerId = useGameStore((s) => s.protectedPlayerId);
+  const lastProtectedPlayerId = useGameStore((s) => s.lastProtectedPlayerId);
+  const loversIds = useGameStore((s) => s.loversIds);
 
   const completeNightStep = useGameStore((s) => s.completeNightStep);
   const setEliminatedThisNight = useGameStore((s) => s.setEliminatedThisNight);
@@ -27,10 +30,12 @@ export default function NightPhase() {
   const infectPlayer = useGameStore((s) => s.infectPlayer);
   const setWolfVictimIdStore = useGameStore((s) => s.setWolfVictimId);
   const setRavenCursed = useGameStore((s) => s.setRavenCursed);
+  const setProtectedPlayerIdStore = useGameStore((s) => s.setProtectedPlayerId);
 
   const [witchSave, setWitchSave] = useState(false);
   const [witchKill, setWitchKill] = useState('');
   const [wolfVictim, setWolfVictim] = useState('');
+  const [protectorTarget, setProtectorTarget] = useState('');
   const [bigBadWolfExtra, setBigBadWolfExtra] = useState('');
   const [seerTarget, setSeerTarget] = useState('');
   const [loversP1, setLoversP1] = useState('');
@@ -70,9 +75,33 @@ export default function NightPhase() {
   const wolfTargets = players.filter((p) => !isWolfAligned(p));
   const cupidIds = players.filter((p) => p.roleId === 'cupid').map((p) => p.id);
   const wildChildId = players.find((p) => p.roleId === 'wild_child')?.id ?? null;
+  const protectablePlayers = players.filter((p) => p.id !== lastProtectedPlayerId);
+  const protectedPlayer = protectedPlayerId
+    ? allPlayers.find((p) => p.id === protectedPlayerId) ?? null
+    : null;
+  const protectedWolfTarget = protectedPlayerId
+    ? wolfTargets.find((p) => p.id === protectedPlayerId) ?? null
+    : null;
+  const currentWolfTargets = wolfTargets.filter((p) => p.id !== protectedPlayerId);
+  const bigBadWolfTargets = players.filter(
+    (p) => p.id !== wolfVictim && !eliminatedThisNight.includes(p.id) && !isWolfAligned(p)
+  );
+  const protectedBigBadTarget = protectedPlayerId
+    ? bigBadWolfTargets.find((p) => p.id === protectedPlayerId) ?? null
+    : null;
+  const currentBigBadTargets = bigBadWolfTargets.filter((p) => p.id !== protectedPlayerId);
+  const canCompleteStep =
+    currentRole?.id !== 'protector' ||
+    protectablePlayers.length === 0 ||
+    protectablePlayers.some((p) => p.id === protectorTarget);
+  const nightResolutionPreview = useMemo(
+    () => resolveNightEliminations(allPlayers, eliminatedThisNight, infectedPlayerIds, loversIds),
+    [allPlayers, eliminatedThisNight, infectedPlayerIds, loversIds]
+  );
 
   const resetLocalState = () => {
     setWolfVictim('');
+    setProtectorTarget('');
     setBigBadWolfExtra('');
     setSeerTarget('');
     setWitchSave(false);
@@ -90,6 +119,12 @@ export default function NightPhase() {
 
   const handleCompleteStep = () => {
     if (!currentRole) return;
+    if (!canCompleteStep) return;
+
+    if (currentRole.id === 'protector') {
+      const validTarget = protectablePlayers.find((p) => p.id === protectorTarget);
+      setProtectedPlayerIdStore(validTarget ? protectorTarget : null);
+    }
 
     if (currentRole.id === 'werewolf') {
       const target = players.find((p) => p.id === wolfVictim);
@@ -179,12 +214,42 @@ export default function NightPhase() {
         <div className="night-instruction">{currentRole.nightAction?.description}</div>
 
         {/* Werewolf: pick victim */}
+        {currentRole.id === 'protector' && (
+          <div className="night-input">
+            {lastProtectedPlayerId && (
+              <p className="protect-note">
+                🕘 Last night&apos;s protection: <strong>{allPlayers.find((p) => p.id === lastProtectedPlayerId)?.name ?? 'Unknown'}</strong>. You cannot protect the same player twice in a row.
+              </p>
+            )}
+            {protectablePlayers.length === 0 ? (
+              <div className="used-banner">🛡️ No valid protection target remains tonight.</div>
+            ) : (
+              <>
+                <label>🛡️ Protector guards:</label>
+                <select value={protectorTarget} onChange={(e) => setProtectorTarget(e.target.value)}>
+                  <option value="">&mdash; Select player &mdash;</option>
+                  {protectablePlayers.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+                </select>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Werewolf: pick victim */}
         {currentRole.id === 'werewolf' && (
           <div className="night-input">
+            {protectedPlayer && (
+              <p className="protected-banner">🛡️ Protected tonight: <strong>{protectedPlayer.name}</strong></p>
+            )}
             <label>&#127919; Wolves choose their victim:</label>
             <select value={wolfVictim} onChange={(e) => setWolfVictim(e.target.value)}>
               <option value="">&mdash; Select target (optional) &mdash;</option>
-              {wolfTargets.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+              {protectedWolfTarget && (
+                <option value={protectedWolfTarget.id} disabled>
+                  🛡️ {protectedWolfTarget.name} (Protected)
+                </option>
+              )}
+              {currentWolfTargets.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
             </select>
           </div>
         )}
@@ -217,6 +282,9 @@ export default function NightPhase() {
         {/* Big Bad Wolf: optional extra kill */}
         {currentRole.id === 'big_bad_wolf' && (
           <div className="night-input">
+            {protectedPlayer && (
+              <p className="protected-banner">🛡️ Protected tonight: <strong>{protectedPlayer.name}</strong></p>
+            )}
             {anyWolfEliminated ? (
               <div className="used-banner">&#9888;&#65039; A wolf has been eliminated &mdash; Big Bad Wolf&apos;s extra kill power is GONE.</div>
             ) : (
@@ -224,9 +292,12 @@ export default function NightPhase() {
                 <label>&#128023; OPTIONAL extra victim (while no wolf eliminated):</label>
                 <select value={bigBadWolfExtra} onChange={(e) => setBigBadWolfExtra(e.target.value)}>
                   <option value="">&mdash; Skip extra kill &mdash;</option>
-                  {players
-                    .filter((p) => p.id !== wolfVictim && !eliminatedThisNight.includes(p.id) && !isWolfAligned(p))
-                    .map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+                  {protectedBigBadTarget && (
+                    <option value={protectedBigBadTarget.id} disabled>
+                      🛡️ {protectedBigBadTarget.name} (Protected)
+                    </option>
+                  )}
+                  {currentBigBadTargets.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
                 </select>
               </>
             )}
@@ -433,6 +504,7 @@ export default function NightPhase() {
             className="btn btn-primary btn-large"
             data-testid="night-next"
             onClick={handleCompleteStep}
+            disabled={!canCompleteStep}
           >
             &#9989; Done &mdash; Next
           </button>
@@ -440,13 +512,13 @@ export default function NightPhase() {
       ) : (
         <div className="night-summary">
           <h3>&#127749; Night ends</h3>
-          {eliminatedThisNight.length === 0 ? (
+          {nightResolutionPreview.finalEliminated.length === 0 ? (
             <p>No one was eliminated tonight. &#128570;</p>
           ) : (
             <p>
               Eliminated:{' '}
               <strong>
-                {eliminatedThisNight
+                {nightResolutionPreview.finalEliminated
                   .map((id) => allPlayers.find((p) => p.id === id)?.name)
                   .join(', ')}
               </strong>

--- a/src/components/Game/NightPhase.tsx
+++ b/src/components/Game/NightPhase.tsx
@@ -1,6 +1,13 @@
 import { useMemo, useState } from 'react';
 import { resolveNightEliminations, useGameStore } from '../../store/gameStore';
-import { ROLE_MAP, WOLF_ROLE_IDS } from '../../data/roles';
+import {
+  ROLE_MAP,
+  WOLF_ROLE_IDS,
+  getRoleTexts,
+  getRoleName,
+  isPlayerWolfIdentity,
+} from '../../data/roles';
+import { getCampLabel, useI18n } from '../../i18n';
 import '../../styles/night.css';
 
 const PASSIVE_REMINDER_ROLE_IDS = ['bear_tamer', 'elder', 'village_idiot', 'scapegoat', 'hunter', 'angel'];
@@ -18,6 +25,9 @@ export default function NightPhase() {
   const wolfVictimId = useGameStore((s) => s.wolfVictimId);
   const wolfDogChoiceStore = useGameStore((s) => s.wolfDogChoice);
   const wildChildTransformed = useGameStore((s) => s.wildChildTransformed);
+  const foxPowerActive = useGameStore((s) => s.foxPowerActive);
+  const enchantedPlayerIds = useGameStore((s) => s.enchantedPlayerIds);
+  const protectorHistory = useGameStore((s) => s.protectorHistory);
   const protectedPlayerId = useGameStore((s) => s.protectedPlayerId);
   const lastProtectedPlayerId = useGameStore((s) => s.lastProtectedPlayerId);
   const loversIds = useGameStore((s) => s.loversIds);
@@ -33,12 +43,13 @@ export default function NightPhase() {
   const infectPlayer = useGameStore((s) => s.infectPlayer);
   const setWolfVictimIdStore = useGameStore((s) => s.setWolfVictimId);
   const setRavenCursed = useGameStore((s) => s.setRavenCursed);
-  const setProtectedPlayerIdStore = useGameStore((s) => s.setProtectedPlayerId);
+  const setFoxPowerActiveStore = useGameStore((s) => s.setFoxPowerActive);
+  const goToNightStepStore = useGameStore((s) => s.goToNightStep);
+  const setProtectorTargetStore = useGameStore((s) => s.setProtectorTarget);
 
   const [witchSave, setWitchSave] = useState(false);
   const [witchKill, setWitchKill] = useState('');
   const [wolfVictim, setWolfVictim] = useState('');
-  const [protectorTarget, setProtectorTarget] = useState('');
   const [bigBadWolfExtra, setBigBadWolfExtra] = useState('');
   const [seerTarget, setSeerTarget] = useState('');
   const [loversP1, setLoversP1] = useState('');
@@ -61,29 +72,24 @@ export default function NightPhase() {
   const currentRoleText = currentRole ? getRoleTexts(currentRole, language) : null;
   const currentRoleName = currentRole ? getRoleName(currentRole, language) : '';
 
-  const passiveReminderRoles = useMemo(
-    () => {
-      const uniqueRoleIds = [...new Set(allPlayers.map((p) => p.roleId))];
-      return uniqueRoleIds
-        .map((id) => ROLE_MAP[id])
-        .filter(
-          (r): r is NonNullable<typeof ROLE_MAP[string]> =>
-            !!r && PASSIVE_REMINDER_ROLE_IDS.includes(r.id)
-        );
-    },
-    [allPlayers]
-  );
+  const passiveReminderRoles = useMemo(() => {
+    const uniqueRoleIds = [...new Set(allPlayers.map((p) => p.roleId))];
+    return uniqueRoleIds
+      .map((id) => ROLE_MAP[id])
+      .filter(
+        (r): r is NonNullable<typeof ROLE_MAP[string]> =>
+          !!r && PASSIVE_REMINDER_ROLE_IDS.includes(r.id)
+      );
+  }, [allPlayers]);
 
   const witchHealUsed = usedGameAbilities.includes('witch_heal');
   const witchPoisonUsed = usedGameAbilities.includes('witch_poison');
   const infectPereUsed = usedGameAbilities.includes('infect_pere');
 
-  // Has any wolf-aligned player been eliminated already?
   const anyWolfEliminated = allPlayers.some(
     (p) => !p.isAlive && (WOLF_ROLE_IDS.includes(p.roleId) || infectedPlayerIds.includes(p.id))
   );
 
-  // Alive pure wolves (not white werewolf) for White Werewolf target
   const alivePureWolves = players.filter(
     (p) => WOLF_ROLE_IDS.includes(p.roleId) && p.roleId !== 'white_werewolf'
   );
@@ -104,25 +110,63 @@ export default function NightPhase() {
   const wolfTargets = players.filter((p) => !isWolfAligned(p));
   const cupidIds = players.filter((p) => p.roleId === 'cupid').map((p) => p.id);
   const wildChildId = players.find((p) => p.roleId === 'wild_child')?.id ?? null;
-  const protectablePlayers = players.filter((p) => p.id !== lastProtectedPlayerId);
-  const protectedPlayer = protectedPlayerId
-    ? allPlayers.find((p) => p.id === protectedPlayerId) ?? null
+  const piperEligiblePlayers = useMemo(
+    () => players.filter((p) => !enchantedPlayerIds.includes(p.id)),
+    [players, enchantedPlayerIds]
+  );
+  const piperEligibleIds = useMemo(
+    () => new Set(piperEligiblePlayers.map((p) => p.id)),
+    [piperEligiblePlayers]
+  );
+  const protectionThisNight = protectorHistory.find((p) => p.round === round) ?? null;
+  const lastProtection = useMemo(() => {
+    const prior = [...protectorHistory]
+      .filter((p) => p.round < round)
+      .sort((a, b) => b.round - a.round)[0];
+    if (!prior) return null;
+    const targetName = prior.targetId
+      ? allPlayers.find((p) => p.id === prior.targetId)?.name ?? null
+      : null;
+    return { ...prior, targetName };
+  }, [protectorHistory, round, allPlayers]);
+  const previousProtectedPlayerId = lastProtectedPlayerId ?? lastProtection?.targetId ?? null;
+  const currentProtectedPlayerId = protectedPlayerId ?? protectionThisNight?.targetId ?? null;
+  const currentProtectionValue = protectorTouched
+    ? protectorTarget
+    : currentProtectedPlayerId ?? '';
+  const protectablePlayers = players.filter((p) => p.id !== previousProtectedPlayerId);
+  const currentProtectedPlayer = currentProtectedPlayerId
+    ? allPlayers.find((p) => p.id === currentProtectedPlayerId) ?? null
     : null;
-  const protectedWolfTarget = protectedPlayerId
-    ? wolfTargets.find((p) => p.id === protectedPlayerId) ?? null
+  const protectedWolfTarget = currentProtectedPlayerId
+    ? wolfTargets.find((p) => p.id === currentProtectedPlayerId) ?? null
     : null;
-  const currentWolfTargets = wolfTargets.filter((p) => p.id !== protectedPlayerId);
+  const currentWolfTargets = wolfTargets.filter((p) => p.id !== currentProtectedPlayerId);
   const bigBadWolfTargets = players.filter(
     (p) => p.id !== wolfVictim && !eliminatedThisNight.includes(p.id) && !isWolfAligned(p)
   );
-  const protectedBigBadTarget = protectedPlayerId
-    ? bigBadWolfTargets.find((p) => p.id === protectedPlayerId) ?? null
+  const protectedBigBadTarget = currentProtectedPlayerId
+    ? bigBadWolfTargets.find((p) => p.id === currentProtectedPlayerId) ?? null
     : null;
-  const currentBigBadTargets = bigBadWolfTargets.filter((p) => p.id !== protectedPlayerId);
+  const currentBigBadTargets = bigBadWolfTargets.filter((p) => p.id !== currentProtectedPlayerId);
   const canCompleteStep =
     currentRole?.id !== 'protector' ||
     protectablePlayers.length === 0 ||
-    protectablePlayers.some((p) => p.id === protectorTarget);
+    protectablePlayers.some((p) => p.id === currentProtectionValue);
+  const foxHasSingleTrio = players.length === 3;
+  const foxCenterOptions = useMemo(
+    () => (foxHasSingleTrio ? players.slice(0, 1) : players),
+    [foxHasSingleTrio, players]
+  );
+  const selectedFoxCenterId = foxCenterTarget || foxCenterOptions[0]?.id || '';
+  const foxTrioPlayers = useMemo(() => {
+    if (players.length < 3 || !selectedFoxCenterId) return [];
+    const centerIndex = players.findIndex((p) => p.id === selectedFoxCenterId);
+    if (centerIndex === -1) return [];
+    if (players.length === 3) return players;
+    return [-1, 0, 1].map((offset) => players[(centerIndex + offset + players.length) % players.length]);
+  }, [players, selectedFoxCenterId]);
+  const foxFoundWolf = foxTrioPlayers.some((p) => isWolfIdentity(p));
   const nightResolutionPreview = useMemo(
     () => resolveNightEliminations(allPlayers, eliminatedThisNight, infectedPlayerIds, loversIds),
     [allPlayers, eliminatedThisNight, infectedPlayerIds, loversIds]
@@ -130,7 +174,6 @@ export default function NightPhase() {
 
   const resetLocalState = () => {
     setWolfVictim('');
-    setProtectorTarget('');
     setBigBadWolfExtra('');
     setSeerTarget('');
     setWitchSave(false);
@@ -152,11 +195,6 @@ export default function NightPhase() {
   const handleCompleteStep = () => {
     if (!currentRole) return;
     if (!canCompleteStep) return;
-
-    if (currentRole.id === 'protector') {
-      const validTarget = protectablePlayers.find((p) => p.id === protectorTarget);
-      setProtectedPlayerIdStore(validTarget ? protectorTarget : null);
-    }
 
     if (currentRole.id === 'werewolf') {
       const target = players.find((p) => p.id === wolfVictim);
@@ -183,10 +221,8 @@ export default function NightPhase() {
       setEliminatedThisNight([...eliminatedThisNight.filter((id) => id !== whiteWolfTarget), whiteWolfTarget]);
 
     if (currentRole.id === 'protector') {
-      const selectedProtection = protectorTouched
-        ? protectorTarget
-        : protectionThisNight?.targetId ?? '';
-      setProtectorTargetStore(selectedProtection || null);
+      const selectedProtection = protectablePlayers.find((p) => p.id === currentProtectionValue)?.id ?? null;
+      setProtectorTargetStore(selectedProtection);
     }
 
     if (currentRole.id === 'witch') {
@@ -273,32 +309,10 @@ export default function NightPhase() {
         <div className="night-instruction">{currentRoleText?.nightActionDescription}</div>
 
         {/* Werewolf: pick victim */}
-        {currentRole.id === 'protector' && (
-          <div className="night-input">
-            {lastProtectedPlayerId && (
-              <p className="protect-note">
-                🕘 Last night&apos;s protection: <strong>{allPlayers.find((p) => p.id === lastProtectedPlayerId)?.name ?? 'Unknown'}</strong>. You cannot protect the same player twice in a row.
-              </p>
-            )}
-            {protectablePlayers.length === 0 ? (
-              <div className="used-banner">🛡️ No valid protection target remains tonight.</div>
-            ) : (
-              <>
-                <label>🛡️ Protector guards:</label>
-                <select value={protectorTarget} onChange={(e) => setProtectorTarget(e.target.value)}>
-                  <option value="">&mdash; Select player &mdash;</option>
-                  {protectablePlayers.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
-                </select>
-              </>
-            )}
-          </div>
-        )}
-
-        {/* Werewolf: pick victim */}
         {currentRole.id === 'werewolf' && (
           <div className="night-input">
-            {protectedPlayer && (
-              <p className="protected-banner">🛡️ Protected tonight: <strong>{protectedPlayer.name}</strong></p>
+            {currentProtectedPlayer && (
+              <p className="protected-banner">🛡️ Protected tonight: <strong>{currentProtectedPlayer.name}</strong></p>
             )}
             <label>&#127919; Wolves choose their victim:</label>
             <select value={wolfVictim} onChange={(e) => setWolfVictim(e.target.value)}>
@@ -341,8 +355,8 @@ export default function NightPhase() {
         {/* Big Bad Wolf: optional extra kill */}
         {currentRole.id === 'big_bad_wolf' && (
           <div className="night-input">
-            {protectedPlayer && (
-              <p className="protected-banner">🛡️ Protected tonight: <strong>{protectedPlayer.name}</strong></p>
+            {currentProtectedPlayer && (
+              <p className="protected-banner">🛡️ Protected tonight: <strong>{currentProtectedPlayer.name}</strong></p>
             )}
             {anyWolfEliminated ? (
               <div className="used-banner">{t.night.bigBadWolfLocked}</div>
@@ -350,7 +364,7 @@ export default function NightPhase() {
               <>
                 <label>{t.night.bigBadWolfLabel}</label>
                 <select value={bigBadWolfExtra} onChange={(e) => setBigBadWolfExtra(e.target.value)}>
-                  <option value="">&mdash; Skip extra kill &mdash;</option>
+                  <option value="">&mdash; {t.night.skipExtra} &mdash;</option>
                   {protectedBigBadTarget && (
                     <option value={protectedBigBadTarget.id} disabled>
                       🛡️ {protectedBigBadTarget.name} (Protected)
@@ -394,25 +408,33 @@ export default function NightPhase() {
             ) : (
               <p className="witch-victim-info">{t.night.protectorNoPrevious}</p>
             )}
-            <label>{t.night.protectorLabel}</label>
-            <select
-              value={currentProtectionValue}
-              onChange={(e) => {
-                setProtectorTouched(true);
-                setProtectorTargetLocal(e.target.value);
-              }}
-            >
-              <option value="">&mdash; {t.night.protectorNone} &mdash;</option>
-              {players.map((p) => (
-                <option key={p.id} value={p.id} disabled={p.id === (lastProtection?.targetId ?? null)}>
-                  {p.name}
-                </option>
-              ))}
-            </select>
-            {lastProtection?.targetId && (
+            {protectablePlayers.length === 0 ? (
+              <div className="used-banner">🛡️ No valid protection target remains tonight.</div>
+            ) : (
+              <>
+                <label>{t.night.protectorLabel}</label>
+                <select
+                  value={currentProtectionValue}
+                  onChange={(e) => {
+                    setProtectorTouched(true);
+                    setProtectorTargetLocal(e.target.value);
+                  }}
+                >
+                  <option value="">&mdash; Select player &mdash;</option>
+                  {protectablePlayers.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+              </>
+            )}
+            {previousProtectedPlayerId && (
               <p className="infect-note">
                 {t.night.protectorCannotRepeat(
-                  lastProtection.targetName ?? t.night.protectorUnknown
+                  lastProtection?.targetName ??
+                    allPlayers.find((p) => p.id === previousProtectedPlayerId)?.name ??
+                    t.night.protectorUnknown
                 )}
               </p>
             )}

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -25,6 +25,7 @@ interface StoreActions {
   setAngelWon: (val: boolean) => void;
   setWolfVictimId: (id: string | null) => void;
   setRavenCursed: (id: string | null) => void;
+  setProtectedPlayerId: (id: string | null) => void;
   togglePhase: () => void;
   startTimer: () => void;
   stopTimer: () => void;
@@ -72,6 +73,8 @@ const defaultGame: GameState = {
   angelWon: false,
   wolfVictimId: null,
   ravenCursedId: null,
+  protectedPlayerId: null,
+  lastProtectedPlayerId: null,
 };
 
 function buildNightSteps(roleIds: string[], round: number): NightStep[] {
@@ -80,6 +83,60 @@ function buildNightSteps(roleIds: string[], round: number): NightStep[] {
     stepIndex: i,
     completed: false,
   }));
+}
+
+export function resolveNightEliminations(
+  players: Player[],
+  eliminatedThisNight: string[],
+  infectedPlayerIds: string[],
+  loversIds: [string, string] | null
+) {
+  const finalEliminated = [...eliminatedThisNight];
+  let extraLog = '';
+
+  // Knight with Rusty Sword: if Knight was killed by wolves,
+  // the first wolf to their LEFT (seating order) dies at dawn.
+  const knightPlayer = players.find((p) => p.isAlive && p.roleId === 'knight');
+  if (knightPlayer && finalEliminated.includes(knightPlayer.id)) {
+    const total = players.length;
+    const knightIdx = players.findIndex((p) => p.id === knightPlayer.id);
+    for (let offset = 1; offset < total; offset++) {
+      const candidate = players[(knightIdx - offset + total) % total];
+      if (!candidate.isAlive) continue;
+      if (
+        WOLF_ROLE_IDS.includes(candidate.roleId) ||
+        infectedPlayerIds.includes(candidate.id)
+      ) {
+        if (!finalEliminated.includes(candidate.id)) {
+          finalEliminated.push(candidate.id);
+          extraLog = ` ⚔️ Knight's rusty sword: ${candidate.name} dies of tetanus!`;
+        }
+        break;
+      }
+    }
+  }
+
+  let loversLog = '';
+  if (loversIds) {
+    const [loverAId, loverBId] = loversIds;
+    const loverAEliminated = finalEliminated.includes(loverAId);
+    const loverBEliminated = finalEliminated.includes(loverBId);
+
+    if (loverAEliminated !== loverBEliminated) {
+      const chainedId = loverAEliminated ? loverBId : loverAId;
+      const fallenId = loverAEliminated ? loverAId : loverBId;
+      const chainedPlayer = players.find((p) => p.id === chainedId);
+
+      if (chainedPlayer?.isAlive && !finalEliminated.includes(chainedId)) {
+        finalEliminated.push(chainedId);
+        const chainedName = chainedPlayer.name;
+        const fallenName = players.find((p) => p.id === fallenId)?.name ?? 'Unknown';
+        loversLog = ` 💘 Lovers: ${chainedName} dies with ${fallenName}.`;
+      }
+    }
+  }
+
+  return { finalEliminated, extraLog, loversLog };
 }
 
 export const useGameStore = create<GameStore>()(
@@ -131,6 +188,8 @@ export const useGameStore = create<GameStore>()(
           angelWon: false,
           wolfVictimId: null,
           ravenCursedId: null,
+          protectedPlayerId: null,
+          lastProtectedPlayerId: null,
         });
       },
 
@@ -162,36 +221,20 @@ export const useGameStore = create<GameStore>()(
       setAngelWon: (val) => set({ angelWon: val }),
       setWolfVictimId: (id) => set({ wolfVictimId: id }),
       setRavenCursed: (id) => set({ ravenCursedId: id }),
+      setProtectedPlayerId: (id) => set({ protectedPlayerId: id }),
 
       applyNightResults: () => {
         const {
           players, eliminatedThisNight, round, discussionTimeSeconds, optionalRules,
           infectedPlayerIds, wildChildModelId, wildChildTransformed, log,
+          loversIds, protectedPlayerId,
         } = get();
-
-        // Knight with Rusty Sword: if Knight was killed by wolves,
-        // the first wolf to their LEFT (seating order) dies at dawn.
-        const finalEliminated = [...eliminatedThisNight];
-        let extraLog = '';
-        const knightPlayer = players.find((p) => p.isAlive && p.roleId === 'knight');
-        if (knightPlayer && finalEliminated.includes(knightPlayer.id)) {
-          const total = players.length;
-          const knightIdx = players.findIndex((p) => p.id === knightPlayer.id);
-          for (let offset = 1; offset < total; offset++) {
-            const candidate = players[(knightIdx - offset + total) % total];
-            if (!candidate.isAlive) continue;
-            if (
-              WOLF_ROLE_IDS.includes(candidate.roleId) ||
-              infectedPlayerIds.includes(candidate.id)
-            ) {
-              if (!finalEliminated.includes(candidate.id)) {
-                finalEliminated.push(candidate.id);
-                extraLog = ` ⚔️ Knight's rusty sword: ${candidate.name} dies of tetanus!`;
-              }
-              break;
-            }
-          }
-        }
+        const { finalEliminated, extraLog, loversLog } = resolveNightEliminations(
+          players,
+          eliminatedThisNight,
+          infectedPlayerIds,
+          loversIds
+        );
 
         const updated = players.map((p) =>
           finalEliminated.includes(p.id) ? { ...p, isAlive: false } : p
@@ -206,7 +249,7 @@ export const useGameStore = create<GameStore>()(
         const nightSteps = buildNightSteps(roleIds, newRound);
 
         const nightMsg = finalEliminated.length
-          ? `Night ${round}: ${finalEliminated.map((id) => updated.find((p) => p.id === id)?.name).join(', ')} were eliminated.${extraLog}`
+          ? `Night ${round}: ${finalEliminated.map((id) => updated.find((p) => p.id === id)?.name).join(', ')} were eliminated.${extraLog}${loversLog}`
           : `Night ${round}: No one was eliminated (peaceful night).`;
 
         set({
@@ -220,6 +263,8 @@ export const useGameStore = create<GameStore>()(
           optionalRules,
           wildChildTransformed: newWildChildTransformed,
           wolfVictimId: null,
+          protectedPlayerId: null,
+          lastProtectedPlayerId: protectedPlayerId,
         });
       },
 
@@ -233,6 +278,7 @@ export const useGameStore = create<GameStore>()(
             phase: 'night', round: newRound, nightSteps,
             currentNightStepIndex: 0, eliminatedThisNight: [], votes: [], optionalRules,
             ravenCursedId: null,
+            protectedPlayerId: null,
           });
         } else {
           set({ phase: 'day', timerRemaining: discussionTimeSeconds, votes: [] });

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -6,7 +6,6 @@ import type {
   NightStep,
   NightStepState,
   Language,
-  ProtectorRecord,
 } from '../types/game.types';
 import { getNightOrder, WOLF_ROLE_IDS } from '../data/roles';
 import { getStrings } from '../i18n';
@@ -35,7 +34,6 @@ interface StoreActions {
   setFoxPowerActive: (active: boolean) => void;
   setWolfVictimId: (id: string | null) => void;
   setRavenCursed: (id: string | null) => void;
-  setProtectedPlayerId: (id: string | null) => void;
   togglePhase: () => void;
   startTimer: () => void;
   stopTimer: () => void;
@@ -84,6 +82,7 @@ const defaultGame: GameState = {
   angelWon: false,
   wolfVictimId: null,
   ravenCursedId: null,
+  language: 'en',
   protectedPlayerId: null,
   lastProtectedPlayerId: null,
 };
@@ -126,6 +125,8 @@ function captureNightState(state: GameStore): NightStepState {
     wildChildModelId: state.wildChildModelId,
     wolfDogChoice: state.wolfDogChoice,
     protectorHistory: state.protectorHistory.map((p) => ({ ...p })),
+    protectedPlayerId: state.protectedPlayerId,
+    lastProtectedPlayerId: state.lastProtectedPlayerId,
   };
 }
 
@@ -136,10 +137,9 @@ export function resolveNightEliminations(
   loversIds: [string, string] | null
 ) {
   const finalEliminated = [...eliminatedThisNight];
-  let extraLog = '';
+  let knightLog = '';
+  let loversLog = '';
 
-  // Knight with Rusty Sword: if Knight was killed by wolves,
-  // the first wolf to their LEFT (seating order) dies at dawn.
   const knightPlayer = players.find((p) => p.isAlive && p.roleId === 'knight');
   if (knightPlayer && finalEliminated.includes(knightPlayer.id)) {
     const total = players.length;
@@ -153,14 +153,13 @@ export function resolveNightEliminations(
       ) {
         if (!finalEliminated.includes(candidate.id)) {
           finalEliminated.push(candidate.id);
-          extraLog = ` ⚔️ Knight's rusty sword: ${candidate.name} dies of tetanus!`;
+          knightLog = `⚔️ Knight's rusty sword: ${candidate.name} dies of tetanus!`;
         }
         break;
       }
     }
   }
 
-  let loversLog = '';
   if (loversIds) {
     const [loverAId, loverBId] = loversIds;
     const loverAEliminated = finalEliminated.includes(loverAId);
@@ -173,14 +172,13 @@ export function resolveNightEliminations(
 
       if (chainedPlayer?.isAlive && !finalEliminated.includes(chainedId)) {
         finalEliminated.push(chainedId);
-        const chainedName = chainedPlayer.name;
         const fallenName = players.find((p) => p.id === fallenId)?.name ?? 'Unknown';
-        loversLog = ` 💘 Lovers: ${chainedName} dies with ${fallenName}.`;
+        loversLog = `💘 Lovers: ${chainedPlayer.name} dies with ${fallenName}.`;
       }
     }
   }
 
-  return { finalEliminated, extraLog, loversLog };
+  return { finalEliminated, knightLog, loversLog };
 }
 
 export const useGameStore = create<GameStore>()(
@@ -217,27 +215,31 @@ export const useGameStore = create<GameStore>()(
           players,
           nightSteps,
           currentNightStepIndex: 0,
-          eliminatedThisNight: [] as string[],
+          eliminatedThisNight: [],
           timerRemaining: discussionTime,
           discussionTimeSeconds: discussionTime,
           loversIds: null,
           mayorId: null,
           log: [strings.logs.gameStarted(players.length)],
-          usedGameAbilities: [] as string[],
+          usedGameAbilities: [],
           optionalRules,
           foxPowerActive: true,
-          protectorHistory: [] as ProtectorRecord[],
+          protectorHistory: [],
           wildChildModelId: null,
           wildChildTransformed: false,
           wolfDogChoice: null,
-          enchantedPlayerIds: [] as string[],
-          infectedPlayerIds: [] as string[],
+          enchantedPlayerIds: [],
+          infectedPlayerIds: [],
           angelWon: false,
           wolfVictimId: null,
           ravenCursedId: null,
+          language: language ?? 'en',
           protectedPlayerId: null,
           lastProtectedPlayerId: null,
-        });
+        };
+        const snapshotBase = { ...get(), ...nextState, nightStepStates: [] } as GameStore;
+        const nightStepStates = [captureNightState(snapshotBase)];
+        set({ ...nextState, nightStepStates });
       },
 
       resetGame: () => set((s) => ({ ...defaultSetup, ...defaultGame, language: s.language })),
@@ -280,6 +282,8 @@ export const useGameStore = create<GameStore>()(
             wildChildModelId: snapshot.wildChildModelId,
             wolfDogChoice: snapshot.wolfDogChoice,
             protectorHistory: snapshot.protectorHistory.map((p) => ({ ...p })),
+            protectedPlayerId: snapshot.protectedPlayerId,
+            lastProtectedPlayerId: snapshot.lastProtectedPlayerId,
             nightSteps,
             currentNightStepIndex: target,
             nightStepStates: history.slice(0, target + 1),
@@ -305,20 +309,43 @@ export const useGameStore = create<GameStore>()(
       setFoxPowerActive: (active) => set({ foxPowerActive: active }),
       setWolfVictimId: (id) => set({ wolfVictimId: id }),
       setRavenCursed: (id) => set({ ravenCursedId: id }),
-      setProtectedPlayerId: (id) => set({ protectedPlayerId: id }),
+      setProtectorTarget: (targetId) =>
+        set((s) => {
+          const withoutCurrentRound = s.protectorHistory.filter((p) => p.round !== s.round);
+          return {
+            protectorHistory: [...withoutCurrentRound, { round: s.round, targetId }],
+            protectedPlayerId: targetId,
+          };
+        }),
 
       applyNightResults: () => {
         const {
-          players, eliminatedThisNight, round, discussionTimeSeconds, optionalRules,
-          infectedPlayerIds, wildChildModelId, wildChildTransformed, log,
-          loversIds, protectedPlayerId,
+          players,
+          eliminatedThisNight,
+          round,
+          discussionTimeSeconds,
+          optionalRules,
+          infectedPlayerIds,
+          wildChildModelId,
+          wildChildTransformed,
+          log,
+          foxPowerActive,
+          usedGameAbilities,
+          protectorHistory,
+          loversIds,
+          protectedPlayerId,
         } = get();
-        const { finalEliminated, extraLog, loversLog } = resolveNightEliminations(
+        const strings = getStrings(get().language);
+        const extraLogParts: string[] = [];
+        const { finalEliminated, knightLog, loversLog } = resolveNightEliminations(
           players,
           eliminatedThisNight,
           infectedPlayerIds,
           loversIds
         );
+
+        if (knightLog) extraLogParts.push(knightLog);
+        if (loversLog) extraLogParts.push(loversLog);
 
         const witchHealUsed = usedGameAbilities.includes('witch_heal');
         const witchPoisonUsed = usedGameAbilities.includes('witch_poison');
@@ -353,9 +380,16 @@ export const useGameStore = create<GameStore>()(
         const newRound = round + 1;
         const nightSteps = buildNightSteps(roleIds, newRound, foxPowerActive, usedGameAbilities);
 
-        const nightMsg = finalEliminated.length
-          ? `Night ${round}: ${finalEliminated.map((id) => updated.find((p) => p.id === id)?.name).join(', ')} were eliminated.${extraLog}${loversLog}`
-          : `Night ${round}: No one was eliminated (peaceful night).`;
+        const eliminatedNames = finalEliminated
+          .map((id) => updated.find((p) => p.id === id)?.name)
+          .filter(Boolean)
+          .join(', ');
+
+        const nightMsg = strings.logs.nightSummary(
+          round,
+          eliminatedNames || null,
+          extraLogParts.length > 0 ? ` ${extraLogParts.join(' ')}` : ''
+        );
 
         set({
           players: updated,
@@ -376,7 +410,13 @@ export const useGameStore = create<GameStore>()(
 
       togglePhase: () => {
         const {
-          phase, round, players, discussionTimeSeconds, optionalRules, foxPowerActive, usedGameAbilities
+          phase,
+          round,
+          players,
+          discussionTimeSeconds,
+          optionalRules,
+          foxPowerActive,
+          usedGameAbilities,
         } = get();
         if (phase === 'day') {
           const roleIds = [...new Set(players.filter((p) => p.isAlive).map((p) => p.roleId))];
@@ -387,11 +427,14 @@ export const useGameStore = create<GameStore>()(
             round: newRound,
             nightSteps,
             currentNightStepIndex: 0,
-            eliminatedThisNight: [] as string[],
+            eliminatedThisNight: [],
             optionalRules,
             ravenCursedId: null,
             protectedPlayerId: null,
-          });
+          };
+          const snapshotBase = { ...get(), ...nextState, nightStepStates: [] } as GameStore;
+          const nightStepStates = [captureNightState(snapshotBase)];
+          set({ ...nextState, nightStepStates });
         } else {
           set({ phase: 'day', timerRemaining: discussionTimeSeconds, nightStepStates: [] });
         }

--- a/src/styles/night.css
+++ b/src/styles/night.css
@@ -181,6 +181,26 @@
   font-weight: 600;
 }
 
+.protected-banner,
+.protect-note {
+  border-radius: 8px;
+  padding: 0.55rem 0.85rem;
+  font-size: 0.9rem;
+}
+
+.protected-banner {
+  background: rgba(46,160,67,0.12);
+  border: 1px solid rgba(46,160,67,0.4);
+  color: #8ddb9d;
+  box-shadow: inset 0 0 0 1px rgba(46,160,67,0.12);
+}
+
+.protect-note {
+  background: rgba(56,139,253,0.08);
+  border: 1px solid rgba(56,139,253,0.28);
+  color: #8dbbff;
+}
+
 .choice-buttons {
   display: flex;
   gap: 0.7rem;

--- a/src/types/game.types.ts
+++ b/src/types/game.types.ts
@@ -92,4 +92,6 @@ export interface GameState {
   angelWon: boolean;                     // true if Angel was first Day-1 execution
   wolfVictimId: string | null;           // wolf's chosen victim for this night (persists across steps for Witch)
   ravenCursedId: string | null;          // player cursed by Raven last night (+2 votes)
+  protectedPlayerId: string | null;      // player protected by Protector for the current night
+  lastProtectedPlayerId: string | null;  // player protected on the previous night
 }

--- a/src/types/game.types.ts
+++ b/src/types/game.types.ts
@@ -83,6 +83,8 @@ export interface NightStepState {
   wildChildModelId: string | null;
   wolfDogChoice: 'villager' | 'werewolf' | null;
   protectorHistory: ProtectorRecord[];
+  protectedPlayerId: string | null;
+  lastProtectedPlayerId: string | null;
 }
 
 export interface ProtectorRecord {
@@ -115,6 +117,9 @@ export interface GameState {
   angelWon: boolean;                     // true if Angel was first Day-1 execution
   wolfVictimId: string | null;           // wolf's chosen victim for this night (persists across steps for Witch)
   ravenCursedId: string | null;          // player cursed by Raven last night (+2 votes)
+  language: Language;
+  nightStepStates: NightStepState[];     // checkpoints for each night step to allow back navigation
+  protectorHistory: ProtectorRecord[];   // records per-night Protector targets
   protectedPlayerId: string | null;      // player protected by Protector for the current night
   lastProtectedPlayerId: string | null;  // player protected on the previous night
 }

--- a/tests/e2e/protector-night-flow.spec.ts
+++ b/tests/e2e/protector-night-flow.spec.ts
@@ -14,7 +14,7 @@ test('protector marks the saved player for wolves and cannot repeat the same tar
 
   await page.getByTestId('start-game').click();
 
-  const protectorSelect = page.locator('.night-input:has-text("Protector guards") select');
+  const protectorSelect = page.locator('.night-input:has-text("Protector shields this player tonight") select');
   await expect(protectorSelect).toBeVisible();
   await protectorSelect.selectOption({ label: 'Villager A' });
   await page.getByTestId('night-next').click();
@@ -35,8 +35,8 @@ test('protector marks the saved player for wolves and cannot repeat the same tar
   await expect(page.getByTestId('day-phase')).toBeVisible();
   await page.getByRole('button', { name: /Start Night Phase/ }).click();
 
-  const nightTwoProtectorSelect = page.locator('.night-input:has-text("Protector guards") select');
-  await expect(page.locator('.protect-note')).toContainText('Last night');
+  const nightTwoProtectorSelect = page.locator('.night-input:has-text("Protector shields this player tonight") select');
+  await expect(page.locator('.night-input')).toContainText('Last protection');
   const options = await nightTwoProtectorSelect.locator('option').allTextContents();
   expect(options.some((opt) => opt.includes('Villager A'))).toBeFalsy();
 });
@@ -60,7 +60,7 @@ test('lovers still die together at night even when one lover was protected', asy
   await cupidRow.locator('select').nth(1).selectOption({ label: 'Lover B' });
   await page.getByTestId('night-next').click();
 
-  const protectorSelect = page.locator('.night-input:has-text("Protector guards") select');
+  const protectorSelect = page.locator('.night-input:has-text("Protector shields this player tonight") select');
   await protectorSelect.selectOption({ label: 'Lover A' });
   await page.getByTestId('night-next').click();
 

--- a/tests/e2e/protector-night-flow.spec.ts
+++ b/tests/e2e/protector-night-flow.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+
+test('protector marks the saved player for wolves and cannot repeat the same target next night', async ({ page }) => {
+  const roles = ['protector', 'werewolf', 'big_bad_wolf', 'villager', 'villager', 'villager'];
+  const names = ['Protector', 'Wolf A', 'Wolf B', 'Villager A', 'Villager B', 'Villager C'];
+
+  await page.goto('/');
+
+  for (const [index, roleId] of roles.entries()) {
+    const row = page.getByTestId(`player-row-${index}`);
+    await row.getByRole('textbox').fill(names[index]);
+    await row.getByTestId('role-select').selectOption(roleId);
+  }
+
+  await page.getByTestId('start-game').click();
+
+  const protectorSelect = page.locator('.night-input:has-text("Protector guards") select');
+  await expect(protectorSelect).toBeVisible();
+  await protectorSelect.selectOption({ label: 'Villager A' });
+  await page.getByTestId('night-next').click();
+
+  await expect(page.locator('.protected-banner')).toContainText('Protected tonight: Villager A');
+  const wolvesSelect = page.locator('.night-input:has-text("Wolves choose their victim") select');
+  await expect(wolvesSelect).toBeVisible();
+  await expect(wolvesSelect.locator('option', { hasText: 'Villager A (Protected)' })).toBeDisabled();
+  await wolvesSelect.selectOption({ label: 'Villager B' });
+  await page.getByTestId('night-next').click();
+
+  await expect(page.locator('.protected-banner')).toContainText('Protected tonight: Villager A');
+  const bigBadSelect = page.locator('.night-input:has-text("OPTIONAL extra victim") select');
+  await expect(bigBadSelect.locator('option', { hasText: 'Villager A (Protected)' })).toBeDisabled();
+  await page.getByTestId('night-next').click();
+
+  await page.getByTestId('reveal-day').click();
+  await expect(page.getByTestId('day-phase')).toBeVisible();
+  await page.getByRole('button', { name: /Start Night Phase/ }).click();
+
+  const nightTwoProtectorSelect = page.locator('.night-input:has-text("Protector guards") select');
+  await expect(page.locator('.protect-note')).toContainText('Last night');
+  const options = await nightTwoProtectorSelect.locator('option').allTextContents();
+  expect(options.some((opt) => opt.includes('Villager A'))).toBeFalsy();
+});
+
+test('lovers still die together at night even when one lover was protected', async ({ page }) => {
+  const roles = ['cupid', 'protector', 'werewolf', 'big_bad_wolf', 'villager', 'villager'];
+  const names = ['Cupid', 'Protector', 'Wolf A', 'Wolf B', 'Lover A', 'Lover B'];
+
+  await page.goto('/');
+
+  for (const [index, roleId] of roles.entries()) {
+    const row = page.getByTestId(`player-row-${index}`);
+    await row.getByRole('textbox').fill(names[index]);
+    await row.getByTestId('role-select').selectOption(roleId);
+  }
+
+  await page.getByTestId('start-game').click();
+
+  const cupidRow = page.locator('.night-input:has-text("Cupid links these two lovers")');
+  await cupidRow.locator('select').nth(0).selectOption({ label: 'Lover A' });
+  await cupidRow.locator('select').nth(1).selectOption({ label: 'Lover B' });
+  await page.getByTestId('night-next').click();
+
+  const protectorSelect = page.locator('.night-input:has-text("Protector guards") select');
+  await protectorSelect.selectOption({ label: 'Lover A' });
+  await page.getByTestId('night-next').click();
+
+  const wolvesSelect = page.locator('.night-input:has-text("Wolves choose their victim") select');
+  await expect(page.locator('.protected-banner')).toContainText('Protected tonight: Lover A');
+  await expect(wolvesSelect.locator('option', { hasText: 'Lover A (Protected)' })).toBeDisabled();
+  await wolvesSelect.selectOption({ label: 'Lover B' });
+  await page.getByTestId('night-next').click();
+
+  const bigBadSelect = page.locator('.night-input:has-text("OPTIONAL extra victim") select');
+  await expect(bigBadSelect.locator('option', { hasText: 'Lover A (Protected)' })).toBeDisabled();
+  await page.getByTestId('night-next').click();
+
+  await expect(page.getByRole('heading', { name: /Night ends/i })).toBeVisible();
+  const summary = page.locator('.night-summary');
+  await expect(summary).toContainText('Lover A');
+  await expect(summary).toContainText('Lover B');
+
+  await page.getByTestId('reveal-day').click();
+  await expect(page.getByRole('heading', { name: /Werewolves Win!/i })).toBeVisible();
+  await expect(page.locator('.alive-chip')).toContainText('4 alive');
+});


### PR DESCRIPTION
## Summary
- implement Protector as a real night action with current-night and previous-night tracking
- show the protected player to the DM during the werewolf and Big Bad Wolf turns with a shield marker and disabled protected option
- enforce lover chaining during night resolution so lovers always die together, even if the surviving lover was protected

## Why
The protector role existed in the role list but had no playable night action or resolution state. Night resolution also only chained lover deaths during daytime eliminations, which let protected lovers survive incorrectly at night.

## Impact
DMs can now reliably see who is protected during wolf targeting, the Protector cooldown rule is enforced, and lover deaths follow the intended rules during night resolution and preview.

## Validation
- `npm run build`
- `npx playwright test tests/e2e/protector-night-flow.spec.ts tests/e2e/selection-restrictions.spec.ts`