### PR TITLE
[codex] Fix White Werewolf endgame handling

### DIFF
--- a/src/components/Game/GameBoard.tsx
+++ b/src/components/Game/GameBoard.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useGameStore } from '../../store/gameStore';
-import { WOLF_ROLE_IDS, LONER_ROLE_IDS } from '../../data/roles';
+import { WOLF_ROLE_IDS, INDEPENDENT_LONER_ROLE_IDS } from '../../data/roles';
 import NightPhase from './NightPhase';
 import DayPhase from './DayPhase';
 import RoleReference from '../Roles/RoleReference';
@@ -35,11 +35,16 @@ export default function GameBoard() {
     (p.roleId === 'wild_child' && wildChildTransformed) ||
     infectedPlayerIds.includes(p.id);
 
-  const wolfCount = alivePlayers.filter(isWolfAligned).length;
+  const packWolfCount = alivePlayers.filter(isWolfAligned).length;
+  const whiteWolfAlive = alivePlayers.some((p) => p.roleId === 'white_werewolf');
 
-  // Loners are not counted as village (they have independent win conditions)
+  // Village parity excludes pack wolves, White Werewolf, and truly independent loners.
   const villageCount = alivePlayers.filter(
-    (p) => !isWolfAligned(p) && !LONER_ROLE_IDS.includes(p.roleId)
+    (p) => (
+      !isWolfAligned(p) &&
+      p.roleId !== 'white_werewolf' &&
+      !INDEPENDENT_LONER_ROLE_IDS.includes(p.roleId)
+    )
   ).length;
 
   // Pied Piper wins when ALL other alive players are enchanted
@@ -53,8 +58,13 @@ export default function GameBoard() {
     alivePlayers.length === 1 && alivePlayers[0]?.roleId === 'white_werewolf';
 
   // Standard win conditions
-  const villageWins = wolfCount === 0 && !piedPiperWins && !whiteWolfWins && !angelWon;
-  const wolvesWin = wolfCount > 0 && wolfCount >= villageCount && !piedPiperWins && !whiteWolfWins && !angelWon;
+  const villageWins = packWolfCount === 0 && !whiteWolfAlive && !piedPiperWins && !whiteWolfWins && !angelWon;
+  const wolvesWin =
+    packWolfCount > 0 &&
+    packWolfCount >= villageCount &&
+    !piedPiperWins &&
+    !whiteWolfWins &&
+    !angelWon;
 
   const gameOver = villageWins || wolvesWin || piedPiperWins || whiteWolfWins || angelWon;
 
@@ -78,7 +88,7 @@ export default function GameBoard() {
             {t.game.phaseChip(phase, round)}
           </span>
           <span className="alive-chip">{t.game.alive(alivePlayers.length)}</span>
-          <span className="wolf-chip">{t.game.wolves(wolfCount)}</span>
+          <span className="wolf-chip">{t.game.wolves(packWolfCount)}</span>
         </div>
         <div className="topbar-right">
           <LanguageToggle compact />

--- a/src/components/Setup/SetupScreen.tsx
+++ b/src/components/Setup/SetupScreen.tsx
@@ -99,8 +99,8 @@ export default function SetupScreen() {
     if (count < def.minCount)
       errors.push(t.setup.errors.notEnough(roleLabel, def.minCount));
   });
-  const wolfCount = roleCounts['werewolf'] ?? 0;
-  if (wolfCount === 0)
+  const wolfSideCount = (roleCounts['werewolf'] ?? 0) + (roleCounts['white_werewolf'] ?? 0);
+  if (wolfSideCount === 0)
     errors.push(t.setup.errors.needWolf);
   const sistersDef = SETUP_ROLES.find((r) => r.id === 'soeurs');
   if (sistersDef && (roleCounts['soeurs'] ?? 0) === 1)

--- a/src/data/roles.ts
+++ b/src/data/roles.ts
@@ -648,8 +648,8 @@ export function isPlayerWolfIdentity(
   );
 }
 
-/** Role IDs that are loners (win alone, not with village or wolves) */
-export const LONER_ROLE_IDS = ['white_werewolf', 'pied_piper', 'angel'];
+/** Independent loners that should be excluded from village/wolf endgame parity. */
+export const INDEPENDENT_LONER_ROLE_IDS = ['pied_piper', 'angel'];
 
 /** Returns night-phase roles in night order (ascending) for a given set of roleIds and round */
 export function getNightOrder(

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -275,7 +275,7 @@ const translations: Record<Language, Strings> = {
       errors: {
         tooMany: (name: string, max: number) => `Too many "${name}" (max ${max}).`,
         notEnough: (name: string, min: number) => `Not enough "${name}" (min ${min}).`,
-        needWolf: 'You must have at least 1 Werewolf.',
+        needWolf: 'You must have at least 1 wolf-side role (Werewolf or White Werewolf).',
         pairRequired: (name: string) => `"${name}" must be assigned either 0 or 2 times.`,
       },
     },
@@ -557,7 +557,7 @@ const translations: Record<Language, Strings> = {
       errors: {
         tooMany: (name: string, max: number) => `Trop de « ${name} » (max ${max}).`,
         notEnough: (name: string, min: number) => `Pas assez de « ${name} » (min ${min}).`,
-        needWolf: 'Vous devez avoir au moins 1 Loup-Garou.',
+        needWolf: 'Vous devez avoir au moins 1 rôle du camp des loups (Loup-Garou ou Loup-Garou Blanc).',
         pairRequired: (name: string) => `« ${name} » doit être attribué soit 0 soit 2 fois.`,
       },
     },

--- a/tests/e2e/white-wolf-endgame.spec.ts
+++ b/tests/e2e/white-wolf-endgame.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function setupGame(page: Page, roles: string[], names: string[]) {
+  await page.goto('/');
+
+  for (const [index, roleId] of roles.entries()) {
+    const row = page.getByTestId(`player-row-${index}`);
+    await row.getByRole('textbox').fill(names[index]);
+    await row.getByTestId('role-select').selectOption(roleId);
+  }
+
+  await page.getByTestId('start-game').click();
+}
+
+async function advanceToDay(page: Page) {
+  if (await page.getByTestId('night-next').isVisible().catch(() => false)) {
+    await page.getByTestId('night-next').click();
+  }
+
+  await expect(page.getByTestId('reveal-day')).toBeVisible();
+  await page.getByTestId('reveal-day').click();
+  await expect(page.getByTestId('day-phase')).toBeVisible();
+}
+
+async function eliminatePlayer(page: Page, name: string) {
+  const card = page.locator('.player-card').filter({ hasText: name });
+  await expect(card).toHaveCount(1);
+  await card.getByRole('button', { name: /Elim\./ }).click();
+}
+
+test('white-wolf-only setup is valid and does not auto-end as a village win', async ({ page }) => {
+  await setupGame(
+    page,
+    ['white_werewolf', 'villager', 'villager', 'villager', 'villager', 'villager'],
+    ['White Wolf', 'Villager A', 'Villager B', 'Villager C', 'Villager D', 'Villager E']
+  );
+
+  await expect(page.getByTestId('night-phase')).toBeVisible();
+  await expect(page.locator('.win-screen')).toHaveCount(0);
+  await expect(page.getByTestId('reveal-day')).toBeVisible();
+});
+
+test('two wolves plus white wolf does not auto-end on parity at game start', async ({ page }) => {
+  await setupGame(
+    page,
+    ['werewolf', 'werewolf', 'white_werewolf', 'villager', 'villager', 'villager'],
+    ['Wolf A', 'Wolf B', 'White Wolf', 'Villager A', 'Villager B', 'Villager C']
+  );
+
+  await expect(page.getByTestId('night-phase')).toBeVisible();
+  await expect(page.locator('.win-screen')).toHaveCount(0);
+  await expect(page.locator('.wolf-chip')).toContainText('2 wolves');
+});
+
+test('eliminating the last pack wolf while white wolf lives does not give the village the win', async ({ page }) => {
+  await setupGame(
+    page,
+    ['white_werewolf', 'werewolf', 'villager', 'villager', 'villager', 'villager'],
+    ['White Wolf', 'Pack Wolf', 'Villager A', 'Villager B', 'Villager C', 'Villager D']
+  );
+
+  await advanceToDay(page);
+  await eliminatePlayer(page, 'Pack Wolf');
+
+  await expect(page.locator('.win-screen')).toHaveCount(0);
+  await expect(page.getByTestId('day-phase')).toBeVisible();
+});
+
+test('white wolf wins when it becomes the sole survivor', async ({ page }) => {
+  await setupGame(
+    page,
+    ['white_werewolf', 'werewolf', 'villager', 'villager', 'villager', 'villager'],
+    ['White Wolf', 'Pack Wolf', 'Villager A', 'Villager B', 'Villager C', 'Villager D']
+  );
+
+  await advanceToDay(page);
+  await eliminatePlayer(page, 'Pack Wolf');
+  await eliminatePlayer(page, 'Villager A');
+  await eliminatePlayer(page, 'Villager B');
+  await eliminatePlayer(page, 'Villager C');
+  await eliminatePlayer(page, 'Villager D');
+
+  await expect(page.locator('.win-screen')).toHaveCount(1);
+  await expect(page.getByRole('heading', { name: 'White Werewolf Wins!' })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- split White Werewolf from generic loner-based victory counting
- block village victory while White Werewolf is still alive without counting it toward wolf parity
- allow setup compositions where White Werewolf is the only wolf-side role

## Why
The game was ending too early when White Werewolf was the only remaining wolf-side threat. White Werewolf was being treated as a loner for standard victory math, so the village could win even though the role should still keep the game alive until it dies or becomes the sole survivor.

## Changes
- update endgame counting in `GameBoard` to use explicit `packWolfCount`, `whiteWolfAlive`, and `villageCount` buckets
- narrow the independent loner constant so White Werewolf remains visually labeled as a loner without affecting standard victory parity
- relax setup validation and copy so `White Werewolf + villagers` is a valid game start
- add Playwright regression coverage for White Werewolf setup, parity, village-blocking, and sole-survivor victory cases

## Impact
- `1 White Werewolf + 5 villagers` now continues
- `2 wolves + 1 White Werewolf + 3 villagers` now continues
- village victory now requires no pack wolves and no White Werewolf alive
- White Werewolf still wins alone only as sole survivor

## Validation
- `npm run build`
- `npx playwright test tests/e2e/white-wolf-endgame.spec.ts tests/e2e/fox-night.spec.ts`

## Root Cause
Standard endgame logic was reusing a UI-oriented loner classification that included White Werewolf. That classification is correct for presentation, but incorrect for the gameplay rule you wanted.