### PR TITLE
feat: phone-first GM workflow

### DIFF
--- a/.github/workflows/android-qa.yml
+++ b/.github/workflows/android-qa.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Ensure Gradle wrapper is executable
         run: chmod +x android/gradlew
 
-      - name: Build Android variants and unit tests
+      - name: Build Android variants for release and emulator smoke
         working-directory: android
-        run: ./gradlew testDebugUnitTest assembleDebug bundleRelease --stacktrace
+        run: ./gradlew assembleDebug bundleRelease --stacktrace
 
       - name: Upload Android build outputs
         if: always()
@@ -62,7 +62,6 @@ jobs:
           path: |
             android/app/build/outputs/apk/debug/app-debug.apk
             android/app/build/outputs/bundle/release/app-release.aab
-            android/app/build/reports/tests/testDebugUnitTest
             android/build/reports/problems/problems-report.html
           if-no-files-found: ignore
 

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -27,9 +27,21 @@ env:
   PACKAGE_NAME: com.panacota96.loupgarous
 
 jobs:
+  validate-ref:
+    name: Validate Release Ref
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce release/mobile for manual publishing
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ "${GITHUB_REF_NAME}" != "release/mobile" ]; then
+            echo "::error::Manual Android publishing must be run from the release/mobile branch."
+            exit 1
+          fi
+
   build-release:
     name: Android Release Bundle
     runs-on: ubuntu-latest
+    needs: validate-ref
     outputs:
       release_version: ${{ steps.release_meta.outputs.release_version }}
       android_version_name: ${{ steps.release_meta.outputs.android_version_name }}
@@ -64,6 +76,24 @@ jobs:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
           printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > android/release.keystore
+
+      - name: Validate Android signing configuration
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          missing=()
+          [ -z "${ANDROID_KEYSTORE_BASE64:-}" ] && missing+=("ANDROID_KEYSTORE_BASE64")
+          [ -z "${ANDROID_STORE_PASSWORD:-}" ] && missing+=("ANDROID_STORE_PASSWORD")
+          [ -z "${ANDROID_KEY_ALIAS:-}" ] && missing+=("ANDROID_KEY_ALIAS")
+          [ -z "${ANDROID_KEY_PASSWORD:-}" ] && missing+=("ANDROID_KEY_PASSWORD")
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::Missing required Android signing secrets: ${missing[*]}"
+            exit 1
+          fi
 
       - name: Sync Capacitor Android assets
         run: npm run cap:sync

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,15 +116,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Sync web assets into Capacitor Android
-        run: npm run cap:sync
-
       - name: Ensure Gradle wrapper is executable
         run: chmod +x android/gradlew
 
-      - name: Run Android unit test and debug build smoke
+      - name: Run Android unit tests
         working-directory: android
-        run: ./gradlew testDebugUnitTest assembleDebug --stacktrace
+        run: ./gradlew testDebugUnitTest --stacktrace
 
       - name: Upload Android reports
         if: always()
@@ -133,5 +130,4 @@ jobs:
           name: android-unit-build
           path: |
             android/app/build/reports/tests/testDebugUnitTest
-            android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Sync web assets into Capacitor Android
+        run: npm run cap:sync
+
       - name: Ensure Gradle wrapper is executable
         run: chmod +x android/gradlew
 

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -16,9 +16,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  validate-ref:
+    name: Validate Deploy Ref
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce release/web for manual production deploys
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ "${GITHUB_REF_NAME}" != "release/web" ]; then
+            echo "::error::Manual production deploys must be run from the release/web branch."
+            exit 1
+          fi
+
   build:
     name: Web Release Build
     runs-on: ubuntu-latest
+    needs: validate-ref
     outputs:
       release_version: ${{ steps.release_meta.outputs.release_version }}
       release_notes_file: ${{ steps.release_meta.outputs.release_notes_file }}

--- a/src/components/Game/DayPhase.tsx
+++ b/src/components/Game/DayPhase.tsx
@@ -269,6 +269,14 @@ export default function DayPhase() {
                     .join(', ')}
                 </div>
               )}
+
+              {ravenCursedName && !voteAssist && (
+                <div className="day-trigger-item day-raven-bar">{t.day.ravenCurse(ravenCursedName)}</div>
+              )}
+
+              {mayorAlive && !voteAssist && (
+                <div className="day-trigger-item day-mayor-bar">{t.day.mayorReminder(mayorAlive.name)}</div>
+              )}
             </div>
           </section>
         )}

--- a/src/components/Game/DayPhase.tsx
+++ b/src/components/Game/DayPhase.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useGameStore } from '../../store/gameStore';
 import { ROLE_MAP, getRoleTexts, getRoleName, isPlayerWolfIdentity } from '../../data/roles';
 import { useI18n } from '../../i18n';
+import ActionSurface from '../Shared/ActionSurface';
 import PlayerCard from './PlayerCard';
 import Timer from './Timer';
 import TieBreaker from './TieBreaker';
@@ -10,7 +11,7 @@ import '../../styles/day.css';
 export default function DayPhase() {
   const { language, t } = useI18n();
   const players = useGameStore((s) => s.players);
-  const alivePlayers = players.filter((p) => p.isAlive);
+  const seatOrder = useGameStore((s) => s.seatOrder);
   const round = useGameStore((s) => s.round);
   const infectedPlayerIds = useGameStore((s) => s.infectedPlayerIds);
   const enchantedPlayerIds = useGameStore((s) => s.enchantedPlayerIds);
@@ -19,10 +20,16 @@ export default function DayPhase() {
   const ravenCursedId = useGameStore((s) => s.ravenCursedId);
   const foxPowerActive = useGameStore((s) => s.foxPowerActive);
   const usedGameAbilities = useGameStore((s) => s.usedGameAbilities);
+  const voteAssist = useGameStore((s) => s.voteAssist);
+  const resolutionQueue = useGameStore((s) => s.resolutionQueue);
 
   const eliminatePlayer = useGameStore((s) => s.eliminatePlayer);
   const addLog = useGameStore((s) => s.addLog);
   const togglePhase = useGameStore((s) => s.togglePhase);
+  const setVoteAssistActive = useGameStore((s) => s.setVoteAssistActive);
+  const adjustVote = useGameStore((s) => s.adjustVote);
+  const toggleNoVote = useGameStore((s) => s.toggleNoVote);
+  const resetVoteAssist = useGameStore((s) => s.resetVoteAssist);
 
   const [revealAll, setRevealAll] = useState(false);
   const [isTieFlowOpen, setIsTieFlowOpen] = useState(false);
@@ -31,35 +38,50 @@ export default function DayPhase() {
   const [showScapegoatConfirm, setShowScapegoatConfirm] = useState(false);
   const [showTieValidation, setShowTieValidation] = useState(false);
 
-  // Bear Tamer morning signal: use full player list (stable seating order)
-  // and scan for the nearest alive neighbor on each side.
-  const bearTamer = players.find((p) => p.isAlive && p.roleId === 'bear_tamer');
-  const bearGrowls = (() => {
-    if (!bearTamer || players.length < 2) return false;
-    const total = players.length;
-    const idx = players.findIndex((p) => p.id === bearTamer.id);
-    if (idx === -1) return false;
+  const orderedPlayers = useMemo(
+    () =>
+      seatOrder
+        .map((id) => players.find((player) => player.id === id))
+        .filter((player): player is (typeof players)[number] => Boolean(player)),
+    [players, seatOrder]
+  );
+  const alivePlayers = orderedPlayers.filter((player) => player.isAlive);
 
-    const isWolfSide = (p: typeof players[0] | undefined) =>
-      !!p &&
-      isPlayerWolfIdentity(p, {
+  const packWolfCount = alivePlayers.filter((player) =>
+    isPlayerWolfIdentity(player, {
+      infectedPlayerIds,
+      wolfDogChoice,
+      wildChildTransformed,
+    }) && player.roleId !== 'white_werewolf'
+  ).length;
+
+  const bearTamer = orderedPlayers.find((player) => player.isAlive && player.roleId === 'bear_tamer');
+  const bearGrowls = (() => {
+    if (!bearTamer || orderedPlayers.length < 2) return false;
+    const total = orderedPlayers.length;
+    const index = orderedPlayers.findIndex((player) => player.id === bearTamer.id);
+    if (index === -1) return false;
+
+    const isWolfSide = (player: typeof players[number] | undefined) =>
+      !!player &&
+      isPlayerWolfIdentity(player, {
         infectedPlayerIds,
         wolfDogChoice,
         wildChildTransformed,
       });
 
-    let leftNeighbor: typeof players[0] | undefined;
+    let leftNeighbor: typeof players[number] | undefined;
     for (let offset = 1; offset < total; offset++) {
-      const candidate = players[(idx - offset + total) % total];
+      const candidate = orderedPlayers[(index - offset + total) % total];
       if (candidate.isAlive) {
         leftNeighbor = candidate;
         break;
       }
     }
 
-    let rightNeighbor: typeof players[0] | undefined;
+    let rightNeighbor: typeof players[number] | undefined;
     for (let offset = 1; offset < total; offset++) {
-      const candidate = players[(idx + offset) % total];
+      const candidate = orderedPlayers[(index + offset) % total];
       if (candidate.isAlive) {
         rightNeighbor = candidate;
         break;
@@ -69,22 +91,19 @@ export default function DayPhase() {
     return isWolfSide(leftNeighbor) || isWolfSide(rightNeighbor);
   })();
 
-  const mayorAlive = players.find((p) => p.isAlive && p.isMayor) ?? null;
-  const scapegoatPlayer = alivePlayers.find((p) => p.roleId === 'scapegoat') ?? null;
+  const mayorAlive = players.find((player) => player.isAlive && player.isMayor) ?? null;
+  const scapegoatPlayer = alivePlayers.find((player) => player.roleId === 'scapegoat') ?? null;
   const ravenCursedName = ravenCursedId
-    ? players.find((p) => p.id === ravenCursedId)?.name ?? null
+    ? players.find((player) => player.id === ravenCursedId)?.name ?? null
     : null;
-  const foxInGame = players.some((p) => p.roleId === 'fox');
-  const witchInGame = players.some((p) => p.roleId === 'witch' && p.isAlive);
+  const foxInGame = players.some((player) => player.roleId === 'fox');
+  const witchInGame = players.some((player) => player.roleId === 'witch' && player.isAlive);
   const witchHealUsed = usedGameAbilities.includes('witch_heal');
   const witchPoisonUsed = usedGameAbilities.includes('witch_poison');
-  const witchPotionsSpent = witchHealUsed && witchPoisonUsed;
 
-  const activeTieIds = selectedTieIds.filter((id) => alivePlayers.some((p) => p.id === id));
-  const selectedTiePlayers = activeTieIds
-    .map((id) => alivePlayers.find((p) => p.id === id))
-    .filter((player): player is (typeof alivePlayers)[number] => Boolean(player));
-  const selectedTieNames = selectedTiePlayers.map((p) => p.name).join(' & ');
+  const dayTriggers = alivePlayers
+    .map((player) => ROLE_MAP[player.roleId])
+    .filter((role) => role?.dayTrigger);
 
   const resetTieFlow = () => {
     setIsTieFlowOpen(false);
@@ -94,21 +113,10 @@ export default function DayPhase() {
     setShowTieValidation(false);
   };
 
-  const startTieFlow = () => {
-    setIsTieFlowOpen(true);
-    setShowTieBreaker(false);
-    setShowScapegoatConfirm(false);
-    setShowTieValidation(false);
-  };
-
-  const toggleTiePlayer = (playerId: string) => {
-    setShowTieValidation(false);
-    setShowTieBreaker(false);
-    setShowScapegoatConfirm(false);
-    setSelectedTieIds((ids) =>
-      ids.includes(playerId) ? ids.filter((id) => id !== playerId) : [...ids, playerId]
-    );
-  };
+  const selectedTiePlayers = selectedTieIds
+    .map((id) => alivePlayers.find((player) => player.id === id))
+    .filter((player): player is (typeof alivePlayers)[number] => Boolean(player));
+  const selectedTieNames = selectedTiePlayers.map((player) => player.name).join(' & ');
 
   const resolveTie = () => {
     if (selectedTiePlayers.length < 2) {
@@ -134,203 +142,297 @@ export default function DayPhase() {
     resetTieFlow();
   };
 
-  // Day triggers to remind DM.
-  const dayTriggers = alivePlayers
-    .map((p) => ROLE_MAP[p.roleId])
-    .filter((r) => r?.dayTrigger);
+  const effectiveVoteTotals = voteAssist
+    ? alivePlayers.map((player) => {
+        const total = (voteAssist.votes[player.id] ?? 0) + (ravenCursedId === player.id ? 2 : 0);
+        return { playerId: player.id, total };
+      })
+    : [];
+  const highestVote = effectiveVoteTotals.reduce((max, item) => Math.max(max, item.total), 0);
+  const tieLeaders = effectiveVoteTotals.filter((item) => item.total === highestVote && highestVote > 0);
+
+  const metrics = [
+    { label: t.day.metrics.alive, value: String(alivePlayers.length), tone: 'neutral' as const },
+    { label: t.day.metrics.pressure, value: String(packWolfCount), tone: packWolfCount > 0 ? 'danger' as const : 'success' as const },
+    { label: t.day.metrics.unresolved, value: String(resolutionQueue.length), tone: resolutionQueue.length > 0 ? 'day' as const : 'success' as const },
+    { label: t.day.metrics.timer, value: t.timer.label, tone: 'day' as const },
+  ];
 
   return (
-    <div className="day-phase" data-testid="day-phase">
-      <div className="day-header">
-        <span className="phase-icon">☀️</span>
-        <div>
-          <h2>{t.day.title(round)}</h2>
-          <p className="day-subtitle">{t.day.subtitle}</p>
-        </div>
-        <button
-          className="btn btn-ghost btn-sm"
-          data-testid="dm-view-toggle"
-          onClick={() => setRevealAll((r) => !r)}
-        >
-          {revealAll ? t.day.dmView.hide : t.day.dmView.show}
-        </button>
-      </div>
-
-      {bearTamer && (
-        <div className={`bear-signal ${bearGrowls ? 'growl' : 'silent'}`}>
-          <strong>{t.day.bearSignal(bearGrowls)}</strong>
-        </div>
-      )}
-
-      {dayTriggers.length > 0 && (
-        <div className="day-triggers">
-          <h3>{t.day.dmReminders}</h3>
-          {dayTriggers.map((r) =>
-            (() => {
-              const dayText = getRoleTexts(r!, language).dayTrigger;
-              if (!dayText) return null;
-              return (
-                <div key={r!.id} className="day-trigger-item">
-                  {r!.emoji} <strong>{getRoleName(r!, language)}:</strong> {dayText}
-                </div>
-              );
-            })()
-          )}
-        </div>
-      )}
-
-      {foxInGame && (
-        <div className="day-trigger-item">
-          {foxPowerActive ? t.day.foxPowerActive : t.day.foxPowerLost}
-        </div>
-      )}
-
-      {witchInGame && (
-        <div className="day-trigger-item">
-          {t.day.witchPotionsStatus(witchHealUsed, witchPoisonUsed)}
-          {witchPotionsSpent && <span className="win-alert"> {t.day.witchPotionsSpent}</span>}
-        </div>
-      )}
-
-      {alivePlayers.some((p) => p.roleId === 'pied_piper') &&
-        (() => {
-          const aliveEnchantedCount = enchantedPlayerIds.filter(
-            (id) => players.find((p) => p.id === id && p.isAlive)
-          ).length;
-          const piperWins = aliveEnchantedCount >= alivePlayers.length - 1;
-          return (
-            <div className="day-trigger-item day-enchanted-bar">
-              {t.day.piedPiperBar(aliveEnchantedCount, alivePlayers.length - 1)}
-              {piperWins && <span className="win-alert"> {t.day.piedPiperWins}</span>}
-            </div>
-          );
-        })()}
-
-      {infectedPlayerIds.length > 0 && (
-        <div className="day-trigger-item day-infected-bar">
-          {t.day.infectedBar}{' '}
-          {infectedPlayerIds
-            .map((id) => players.find((p) => p.id === id))
-            .filter(Boolean)
-            .map((p) => p!.name)
-            .join(', ')}
-        </div>
-      )}
-
-      <Timer />
-
-      <section className="day-players">
-        <h3>{t.day.playersTitle(alivePlayers.length)}</h3>
-        <div className="players-grid">
-          {players.map((p) => (
-            <PlayerCard key={p.id} playerId={p.id} showRole={revealAll} />
-          ))}
-        </div>
-      </section>
-
-      <section className="voting-section tie-resolution-section" data-testid="tie-resolution-panel">
-        <div className="voting-header">
-          <h3>{t.day.tieResolutionTitle}</h3>
-          {isTieFlowOpen && (
-            <button className="btn btn-ghost btn-sm" onClick={resetTieFlow}>
-              {t.day.tieResolutionCancel}
+    <ActionSurface
+      phase="day"
+      title={t.day.title(round)}
+      subtitle={t.day.subtitle}
+      metrics={metrics}
+      className="day-phase"
+      quickPanel={
+        <div className="gm-quick-panel">
+          <div className="gm-quick-panel__header">
+            <strong>{t.game.quickPanel}</strong>
+          </div>
+          <div className="gm-quick-panel__actions">
+            <button
+              className="btn btn-ghost btn-sm"
+              data-testid="dm-view-toggle"
+              onClick={() => setRevealAll((visible) => !visible)}
+            >
+              {revealAll ? t.day.dmView.hide : t.day.dmView.show}
             </button>
-          )}
+            <button
+              className="btn btn-ghost btn-sm"
+              data-testid="vote-assist-toggle"
+              onClick={() => setVoteAssistActive(!voteAssist)}
+            >
+              {voteAssist ? t.day.voteAssistDisable : t.day.voteAssistEnable}
+            </button>
+            {voteAssist && (
+              <button className="btn btn-ghost btn-sm" onClick={resetVoteAssist}>
+                {t.day.clearVotes}
+              </button>
+            )}
+          </div>
         </div>
+      }
+      footer={
+        <div className="sticky-action-bar">
+          <button className="btn btn-primary btn-large night-btn" onClick={togglePhase}>
+            {t.day.nightButton}
+          </button>
+        </div>
+      }
+    >
+      <div data-testid="day-phase">
+        {resolutionQueue.length > 0 && (
+          <section className="day-panel">
+            <div className="panel-header">
+              <h3>{t.day.resolutionTitle}</h3>
+              <span className="panel-kicker">{t.day.resolutionHint}</span>
+            </div>
+            <div className="resolution-list">
+              {resolutionQueue.map((item) => (
+                <div key={item.id} className={`resolution-item resolution-item--${item.type}`}>
+                  <strong>{item.title}</strong>
+                  <p>{item.detail}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
 
-        <p className="tb-hint">{t.day.tieResolutionHint}</p>
-
-        {ravenCursedName && (
-          <div className="raven-curse-bar">
-            {t.day.ravenCurse(ravenCursedName)}
+        {bearTamer && (
+          <div className={`bear-signal ${bearGrowls ? 'growl' : 'silent'}`}>
+            <strong>{t.day.bearSignal(bearGrowls)}</strong>
           </div>
         )}
 
-        {mayorAlive && (
-          <div className="mayor-vote-bar">{t.day.mayorReminder(mayorAlive.name)}</div>
+        {(dayTriggers.length > 0 || foxInGame || witchInGame || infectedPlayerIds.length > 0) && (
+          <section className="day-panel">
+            <h3>{t.day.dmReminders}</h3>
+            <div className="day-trigger-stack">
+              {dayTriggers.map((role) => {
+                const dayText = getRoleTexts(role!, language).dayTrigger;
+                if (!dayText) return null;
+                return (
+                  <div key={role!.id} className="day-trigger-item">
+                    {role!.emoji} <strong>{getRoleName(role!, language)}:</strong> {dayText}
+                  </div>
+                );
+              })}
+
+              {foxInGame && (
+                <div className="day-trigger-item">
+                  {foxPowerActive ? t.day.foxPowerActive : t.day.foxPowerLost}
+                </div>
+              )}
+
+              {witchInGame && (
+                <div className="day-trigger-item">
+                  {t.day.witchPotionsStatus(witchHealUsed, witchPoisonUsed)}
+                </div>
+              )}
+
+              {alivePlayers.some((player) => player.roleId === 'pied_piper') && (
+                <div className="day-trigger-item day-enchanted-bar">
+                  {t.day.piedPiperBar(
+                    enchantedPlayerIds.filter((id) => alivePlayers.some((player) => player.id === id)).length,
+                    alivePlayers.length - 1
+                  )}
+                </div>
+              )}
+
+              {infectedPlayerIds.length > 0 && (
+                <div className="day-trigger-item day-infected-bar">
+                  {t.day.infectedBar}{' '}
+                  {infectedPlayerIds
+                    .map((id) => players.find((player) => player.id === id)?.name)
+                    .filter(Boolean)
+                    .join(', ')}
+                </div>
+              )}
+            </div>
+          </section>
         )}
 
-        {!isTieFlowOpen ? (
-          <button
-            className="btn btn-yellow"
-            data-testid="tie-resolution-start"
-            disabled={alivePlayers.length < 2}
-            onClick={startTieFlow}
-          >
-            {t.day.tieResolutionStart}
-          </button>
-        ) : (
-          <>
-            <p className="tie-resolution-copy">{t.day.tieResolutionSelectionHint}</p>
-            <div className="tie-resolution-status">
-              {t.day.tieResolutionSelectedCount(selectedTiePlayers.length)}
-            </div>
+        <Timer />
 
-            <div className="tb-player-list">
+        {voteAssist && (
+          <section className="day-panel vote-assist-panel">
+            <div className="panel-header">
+              <h3>{t.day.voteAssistTitle}</h3>
+              <span className="panel-kicker">{t.day.voteAssistHint}</span>
+            </div>
+            {ravenCursedName && (
+              <div className="raven-curse-bar">{t.day.ravenCurse(ravenCursedName)}</div>
+            )}
+            {mayorAlive && (
+              <div className="mayor-vote-bar">{t.day.mayorReminder(mayorAlive.name)}</div>
+            )}
+            <div className="vote-assist-list">
               {alivePlayers.map((player) => {
-                const selected = activeTieIds.includes(player.id);
+                const baseVotes = voteAssist.votes[player.id] ?? 0;
+                const totalVotes = baseVotes + (ravenCursedId === player.id ? 2 : 0);
+                const noVote = voteAssist.noVoteIds.includes(player.id);
                 return (
-                  <button
-                    key={player.id}
-                    type="button"
-                    className={`tb-player ${selected ? 'selected' : ''}`}
-                    aria-pressed={selected}
-                    onClick={() => toggleTiePlayer(player.id)}
-                  >
-                    {player.name}
-                    {player.isMayor && ' 🎖️'}
-                  </button>
+                  <div key={player.id} className={`vote-assist-row ${noVote ? 'vote-assist-row--novote' : ''}`}>
+                    <div>
+                      <strong>{player.name}</strong>
+                      <p>{t.day.totalVotes(totalVotes)}</p>
+                    </div>
+                    <div className="vote-assist-actions">
+                      <button className="btn btn-ghost btn-sm" onClick={() => adjustVote(player.id, -1)}>
+                        −1
+                      </button>
+                      <button className="btn btn-ghost btn-sm" onClick={() => adjustVote(player.id, 1)}>
+                        +1
+                      </button>
+                      <button className="btn btn-yellow btn-sm" onClick={() => adjustVote(player.id, 2)}>
+                        {t.day.mayorPlusTwo}
+                      </button>
+                      <button className="btn btn-ghost btn-sm" onClick={() => toggleNoVote(player.id)}>
+                        {noVote ? t.day.allowVote : t.day.noVote}
+                      </button>
+                    </div>
+                  </div>
                 );
               })}
             </div>
-
-            {showTieValidation && (
-              <div className="tie-resolution-error" data-testid="tie-resolution-error">
-                {t.day.tieResolutionNeedPlayers}
-              </div>
+            {tieLeaders.length > 1 && (
+              <div className="tie-warning">{t.day.tieDetected(tieLeaders.map((item) => alivePlayers.find((player) => player.id === item.playerId)?.name ?? '').join(', '))}</div>
             )}
+          </section>
+        )}
 
-            {!showTieBreaker && !showScapegoatConfirm && (
-              <button
-                className="btn btn-danger"
-                data-testid="tie-resolution-resolve"
-                onClick={resolveTie}
-              >
-                {t.day.tieResolutionResolve}
+        <section className="day-players">
+          <h3>{t.day.playersTitle(alivePlayers.length)}</h3>
+          <div className="players-grid">
+            {orderedPlayers.map((player) => (
+              <PlayerCard key={player.id} playerId={player.id} showRole={revealAll} />
+            ))}
+          </div>
+        </section>
+
+        <section className="day-panel tie-resolution-section" data-testid="tie-resolution-panel">
+          <div className="panel-header">
+            <h3>{t.day.tieResolutionTitle}</h3>
+            {isTieFlowOpen && (
+              <button className="btn btn-ghost btn-sm" onClick={resetTieFlow}>
+                {t.day.tieResolutionCancel}
               </button>
             )}
+          </div>
 
-            {showScapegoatConfirm && scapegoatPlayer && (
-              <div className="tie-warning" data-testid="scapegoat-resolution">
-                <span>{t.day.scapegoatResolution(scapegoatPlayer.name, selectedTieNames)}</span>
-                <button className="btn btn-danger" onClick={confirmScapegoatTie}>
-                  {t.day.confirmScapegoat(scapegoatPlayer.name)}
-                </button>
+          <p className="tb-hint">{t.day.tieResolutionHint}</p>
+
+          {!isTieFlowOpen ? (
+            <button
+              className="btn btn-yellow"
+              data-testid="tie-resolution-start"
+              disabled={alivePlayers.length < 2}
+              onClick={() => {
+                setIsTieFlowOpen(true);
+                setShowTieBreaker(false);
+                setShowScapegoatConfirm(false);
+                setShowTieValidation(false);
+              }}
+            >
+              {t.day.tieResolutionStart}
+            </button>
+          ) : (
+            <>
+              <p className="tie-resolution-copy">{t.day.tieResolutionSelectionHint}</p>
+              <div className="tie-resolution-status">
+                {t.day.tieResolutionSelectedCount(selectedTiePlayers.length)}
               </div>
-            )}
 
-            {showTieBreaker && selectedTiePlayers.length > 1 && !scapegoatPlayer && (
-              <TieBreaker
-                tiedPlayerIds={activeTieIds}
-                players={alivePlayers}
-                t={t}
-                onLog={addLog}
-                onEliminate={(id) => {
-                  eliminatePlayer(id);
-                  resetTieFlow();
-                }}
-                onClose={() => setShowTieBreaker(false)}
-              />
-            )}
-          </>
-        )}
-      </section>
+              <div className="tb-player-list">
+                {alivePlayers.map((player) => {
+                  const selected = selectedTieIds.includes(player.id);
+                  return (
+                    <button
+                      key={player.id}
+                      type="button"
+                      className={`tb-player ${selected ? 'selected' : ''}`}
+                      aria-pressed={selected}
+                      onClick={() => {
+                        setShowTieValidation(false);
+                        setShowTieBreaker(false);
+                        setShowScapegoatConfirm(false);
+                        setSelectedTieIds((ids) =>
+                          ids.includes(player.id)
+                            ? ids.filter((id) => id !== player.id)
+                            : [...ids, player.id]
+                        );
+                      }}
+                    >
+                      {player.name}
+                      {player.isMayor && ' 🎖️'}
+                    </button>
+                  );
+                })}
+              </div>
 
-      <section className="day-footer">
-        <button className="btn btn-primary btn-large night-btn" onClick={togglePhase}>
-          {t.day.nightButton}
-        </button>
-      </section>
-    </div>
+              {showTieValidation && (
+                <div className="tie-resolution-error" data-testid="tie-resolution-error">
+                  {t.day.tieResolutionNeedPlayers}
+                </div>
+              )}
+
+              {!showTieBreaker && !showScapegoatConfirm && (
+                <button
+                  className="btn btn-danger"
+                  data-testid="tie-resolution-resolve"
+                  onClick={resolveTie}
+                >
+                  {t.day.tieResolutionResolve}
+                </button>
+              )}
+
+              {showScapegoatConfirm && scapegoatPlayer && (
+                <div className="tie-warning" data-testid="scapegoat-resolution">
+                  <span>{t.day.scapegoatResolution(scapegoatPlayer.name, selectedTieNames)}</span>
+                  <button className="btn btn-danger" onClick={confirmScapegoatTie}>
+                    {t.day.confirmScapegoat(scapegoatPlayer.name)}
+                  </button>
+                </div>
+              )}
+
+              {showTieBreaker && selectedTiePlayers.length > 1 && !scapegoatPlayer && (
+                <TieBreaker
+                  tiedPlayerIds={selectedTieIds}
+                  players={alivePlayers}
+                  t={t}
+                  onLog={addLog}
+                  onEliminate={(id) => {
+                    eliminatePlayer(id);
+                    resetTieFlow();
+                  }}
+                  onClose={() => setShowTieBreaker(false)}
+                />
+              )}
+            </>
+          )}
+        </section>
+      </div>
+    </ActionSurface>
   );
 }

--- a/src/components/Game/GameBoard.tsx
+++ b/src/components/Game/GameBoard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useGameStore } from '../../store/gameStore';
 import { WOLF_ROLE_IDS, INDEPENDENT_LONER_ROLE_IDS } from '../../data/roles';
 import NightPhase from './NightPhase';
@@ -64,21 +64,21 @@ export default function GameBoard() {
     !angelWon;
   const gameOver = villageWins || wolvesWin || piedPiperWins || whiteWolfWins || angelWon;
 
-  const winner = useMemo(() => {
+  const winner = (() => {
     if (wolvesWin) return 'werewolves';
     if (piedPiperWins) return 'pied_piper';
     if (whiteWolfWins) return 'white_werewolf';
     if (angelWon) return 'angel';
     return 'village';
-  }, [angelWon, piedPiperWins, villageWins, whiteWolfWins, wolvesWin]);
+  })();
 
-  const endReason = useMemo(() => {
+  const endReason = (() => {
     if (winner === 'village') return t.game.endReasons.village;
     if (winner === 'werewolves') return t.game.endReasons.werewolves(packWolfCount, villageCount);
     if (winner === 'pied_piper') return t.game.endReasons.piedPiper;
     if (winner === 'white_werewolf') return t.game.endReasons.whiteWerewolf;
     return t.game.endReasons.angel;
-  }, [packWolfCount, t, villageCount, winner]);
+  })();
 
   const openTab = (nextTab: Tab) => {
     setTab(nextTab);

--- a/src/components/Game/GameBoard.tsx
+++ b/src/components/Game/GameBoard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useGameStore } from '../../store/gameStore';
 import { WOLF_ROLE_IDS, INDEPENDENT_LONER_ROLE_IDS } from '../../data/roles';
 import NightPhase from './NightPhase';
@@ -21,43 +21,40 @@ export default function GameBoard() {
   const infectedPlayerIds = useGameStore((s) => s.infectedPlayerIds);
   const enchantedPlayerIds = useGameStore((s) => s.enchantedPlayerIds);
   const angelWon = useGameStore((s) => s.angelWon);
+  const uiMode = useGameStore((s) => s.uiMode);
+  const setUiMode = useGameStore((s) => s.setUiMode);
+  const privacyMode = useGameStore((s) => s.privacyMode);
+  const togglePrivacyMode = useGameStore((s) => s.togglePrivacyMode);
+  const undoLastAction = useGameStore((s) => s.undoLastAction);
+  const resolutionQueue = useGameStore((s) => s.resolutionQueue);
+  const saveNamedSession = useGameStore((s) => s.saveNamedSession);
   const { t } = useI18n();
 
   const [tab, setTab] = useState<Tab>('game');
   const [isConfigOpen, setIsConfigOpen] = useState(false);
 
-  const alivePlayers = players.filter((p) => p.isAlive);
+  const alivePlayers = players.filter((player) => player.isAlive);
 
-  /** Returns true if this player is wolf-aligned (including transforms) */
-  const isWolfAligned = (p: typeof players[0]) =>
-    WOLF_ROLE_IDS.includes(p.roleId) ||
-    (p.roleId === 'wolf_dog' && wolfDogChoice === 'werewolf') ||
-    (p.roleId === 'wild_child' && wildChildTransformed) ||
-    infectedPlayerIds.includes(p.id);
+  const isWolfAligned = (player: typeof players[0]) =>
+    WOLF_ROLE_IDS.includes(player.roleId) ||
+    (player.roleId === 'wolf_dog' && wolfDogChoice === 'werewolf') ||
+    (player.roleId === 'wild_child' && wildChildTransformed) ||
+    infectedPlayerIds.includes(player.id);
 
   const packWolfCount = alivePlayers.filter(isWolfAligned).length;
-  const whiteWolfAlive = alivePlayers.some((p) => p.roleId === 'white_werewolf');
-
-  // Village parity excludes pack wolves, White Werewolf, and truly independent loners.
+  const whiteWolfAlive = alivePlayers.some((player) => player.roleId === 'white_werewolf');
   const villageCount = alivePlayers.filter(
-    (p) => (
-      !isWolfAligned(p) &&
-      p.roleId !== 'white_werewolf' &&
-      !INDEPENDENT_LONER_ROLE_IDS.includes(p.roleId)
-    )
+    (player) =>
+      !isWolfAligned(player) &&
+      player.roleId !== 'white_werewolf' &&
+      !INDEPENDENT_LONER_ROLE_IDS.includes(player.roleId)
   ).length;
 
-  // Pied Piper wins when ALL other alive players are enchanted
-  const piedPiperAlive = alivePlayers.find((p) => p.roleId === 'pied_piper');
+  const piedPiperAlive = alivePlayers.find((player) => player.roleId === 'pied_piper');
   const piedPiperWins =
     !!piedPiperAlive &&
-    alivePlayers.every((p) => p.roleId === 'pied_piper' || enchantedPlayerIds.includes(p.id));
-
-  // White Werewolf wins as sole survivor
-  const whiteWolfWins =
-    alivePlayers.length === 1 && alivePlayers[0]?.roleId === 'white_werewolf';
-
-  // Standard win conditions
+    alivePlayers.every((player) => player.roleId === 'pied_piper' || enchantedPlayerIds.includes(player.id));
+  const whiteWolfWins = alivePlayers.length === 1 && alivePlayers[0]?.roleId === 'white_werewolf';
   const villageWins = packWolfCount === 0 && !whiteWolfAlive && !piedPiperWins && !whiteWolfWins && !angelWon;
   const wolvesWin =
     packWolfCount > 0 &&
@@ -65,33 +62,78 @@ export default function GameBoard() {
     !piedPiperWins &&
     !whiteWolfWins &&
     !angelWon;
-
   const gameOver = villageWins || wolvesWin || piedPiperWins || whiteWolfWins || angelWon;
 
-  let winner: 'village' | 'werewolves' | 'pied_piper' | 'white_werewolf' | 'angel' = 'village';
-  if (wolvesWin) winner = 'werewolves';
-  else if (piedPiperWins) winner = 'pied_piper';
-  else if (whiteWolfWins) winner = 'white_werewolf';
-  else if (angelWon) winner = 'angel';
+  const winner = useMemo(() => {
+    if (wolvesWin) return 'werewolves';
+    if (piedPiperWins) return 'pied_piper';
+    if (whiteWolfWins) return 'white_werewolf';
+    if (angelWon) return 'angel';
+    return 'village';
+  }, [angelWon, piedPiperWins, villageWins, whiteWolfWins, wolvesWin]);
+
+  const endReason = useMemo(() => {
+    if (winner === 'village') return t.game.endReasons.village;
+    if (winner === 'werewolves') return t.game.endReasons.werewolves(packWolfCount, villageCount);
+    if (winner === 'pied_piper') return t.game.endReasons.piedPiper;
+    if (winner === 'white_werewolf') return t.game.endReasons.whiteWerewolf;
+    return t.game.endReasons.angel;
+  }, [packWolfCount, t, villageCount, winner]);
 
   const openTab = (nextTab: Tab) => {
     setTab(nextTab);
+    setUiMode(nextTab === 'game' ? 'run' : 'reference');
     setIsConfigOpen(false);
   };
 
+  const exportRecap = () => {
+    const lines = [
+      `${t.appTitle} - ${t.game.recapTitle}`,
+      `${t.game.phaseChip(phase, round)}`,
+      '',
+      ...players.map((player) => `${player.name}: ${player.roleId} - ${player.isAlive ? 'alive' : 'dead'}`),
+      '',
+      ...log,
+    ];
+    const blob = new Blob([lines.join('\n')], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `loupgarous-recap-round-${round}.txt`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
-    <div className={`gameboard ${phase}`}>
-      {/* Top bar */}
+    <div className={`gameboard ${phase} ${privacyMode ? 'privacy-on' : ''}`}>
       <div className="gameboard-topbar">
         <div className="topbar-left">
-          <span className="phase-chip">
-            {t.game.phaseChip(phase, round)}
-          </span>
+          <span className="phase-chip">{t.game.phaseChip(phase, round)}</span>
           <span className="alive-chip">{t.game.alive(alivePlayers.length)}</span>
           <span className="wolf-chip">{t.game.wolves(packWolfCount)}</span>
+          <span className="queue-chip">{t.game.unresolved(resolutionQueue.length)}</span>
         </div>
         <div className="topbar-right">
           <LanguageToggle compact />
+          <button className="btn btn-ghost btn-sm" onClick={undoLastAction}>
+            {t.game.undo}
+          </button>
+          <button
+            className="btn btn-ghost btn-sm"
+            data-testid="save-live-session"
+            onClick={() => {
+              const name = window.prompt(
+                t.setup.sessionNamePlaceholder,
+                t.setup.defaultSessionName(players.length)
+              );
+              if (name) saveNamedSession(name);
+            }}
+          >
+            {t.setup.saveSession}
+          </button>
+          <button className="btn btn-ghost btn-sm" onClick={togglePrivacyMode} data-testid="privacy-toggle">
+            {privacyMode ? t.game.privacyOff : t.game.privacyOn}
+          </button>
           <button
             className="btn btn-ghost btn-sm"
             onClick={() => {
@@ -103,7 +145,6 @@ export default function GameBoard() {
         </div>
       </div>
 
-      {/* Win screen */}
       {gameOver && (
         <div className={`win-screen win-${winner}`}>
           {winner === 'village' && (
@@ -141,13 +182,21 @@ export default function GameBoard() {
               <p>{t.game.wins.angel.body}</p>
             </>
           )}
-          <button className="btn btn-primary" onClick={resetGame}>
-            {t.game.newGame}
-          </button>
+          <div className="win-explainer">
+            <strong>{t.game.endReason}</strong>
+            <p>{endReason}</p>
+          </div>
+          <div className="win-actions">
+            <button className="btn btn-ghost" onClick={exportRecap}>
+              {t.game.exportRecap}
+            </button>
+            <button className="btn btn-primary" onClick={resetGame}>
+              {t.game.newGame}
+            </button>
+          </div>
         </div>
       )}
 
-      {/* Tabs */}
       {!gameOver && (
         <>
           <div className="tabs">
@@ -164,14 +213,14 @@ export default function GameBoard() {
                 onClick={() => openTab('roles')}
                 data-testid="gameboard-tab-roles"
               >
-                📚 Roles
+                {t.game.tabs.roles}
               </button>
               <button
                 className={`tab-btn ${tab === 'log' ? 'active' : ''}`}
                 onClick={() => openTab('log')}
                 data-testid="gameboard-tab-log"
               >
-                📜 Log
+                {t.game.tabs.log}
               </button>
             </div>
             <div className="tabs-mobile-config">
@@ -192,7 +241,7 @@ export default function GameBoard() {
                     role="menuitem"
                     data-testid="gameboard-conf-roles"
                   >
-                    📚 Roles
+                    {t.game.tabs.roles}
                   </button>
                   <button
                     className={`conf-menu-item ${tab === 'log' ? 'active' : ''}`}
@@ -200,24 +249,34 @@ export default function GameBoard() {
                     role="menuitem"
                     data-testid="gameboard-conf-log"
                   >
-                    📜 Log
+                    {t.game.tabs.log}
                   </button>
                 </div>
               )}
             </div>
           </div>
 
-          <div className="tab-content">
-            {tab === 'game' && (
-              phase === 'night' ? <NightPhase /> : <DayPhase />
+          <div className={`tab-content ${uiMode === 'reference' ? 'tab-content--reference' : ''}`}>
+            {privacyMode && tab === 'game' && (
+              <div className="privacy-overlay">
+                <strong>{t.game.privacyTitle}</strong>
+                <p>{t.game.privacyBody}</p>
+              </div>
             )}
+
+            {tab === 'game' && (phase === 'night' ? <NightPhase /> : <DayPhase />)}
             {tab === 'roles' && <RoleReference />}
             {tab === 'log' && (
               <div className="game-log">
-                <h3>{t.game.log.title}</h3>
+                <div className="game-log-header">
+                  <h3>{t.game.log.title}</h3>
+                  <button className="btn btn-ghost btn-sm" onClick={exportRecap}>
+                    {t.game.exportRecap}
+                  </button>
+                </div>
                 {log.length === 0 && <p className="log-empty">{t.game.log.empty}</p>}
-                {[...log].reverse().map((entry, i) => (
-                  <div key={i} className="log-entry">
+                {[...log].reverse().map((entry, index) => (
+                  <div key={`${entry}-${index}`} className="log-entry">
                     {entry}
                   </div>
                 ))}

--- a/src/components/Game/NightPhase.tsx
+++ b/src/components/Game/NightPhase.tsx
@@ -7,6 +7,7 @@ import {
   getRoleName,
   isPlayerWolfIdentity,
 } from '../../data/roles';
+import ActionSurface from '../Shared/ActionSurface';
 import { getCampLabel, useI18n } from '../../i18n';
 import '../../styles/night.css';
 
@@ -31,6 +32,7 @@ export default function NightPhase() {
   const protectedPlayerId = useGameStore((s) => s.protectedPlayerId);
   const lastProtectedPlayerId = useGameStore((s) => s.lastProtectedPlayerId);
   const loversIds = useGameStore((s) => s.loversIds);
+  const seatOrder = useGameStore((s) => s.seatOrder);
 
   const completeNightStep = useGameStore((s) => s.completeNightStep);
   const setEliminatedThisNight = useGameStore((s) => s.setEliminatedThisNight);
@@ -168,9 +170,23 @@ export default function NightPhase() {
   }, [players, selectedFoxCenterId]);
   const foxFoundWolf = foxTrioPlayers.some((p) => isWolfIdentity(p));
   const nightResolutionPreview = useMemo(
-    () => resolveNightEliminations(allPlayers, eliminatedThisNight, infectedPlayerIds, loversIds),
-    [allPlayers, eliminatedThisNight, infectedPlayerIds, loversIds]
+    () => resolveNightEliminations(allPlayers, eliminatedThisNight, infectedPlayerIds, loversIds, seatOrder),
+    [allPlayers, eliminatedThisNight, infectedPlayerIds, loversIds, seatOrder]
   );
+  const metrics = [
+    { label: '🫀', value: String(players.length), tone: 'neutral' as const },
+    { label: '🐺', value: String(alivePureWolves.length), tone: 'danger' as const },
+    {
+      label: '📍',
+      value: allStepsDone ? t.night.nightEnds : `${Math.min(currentNightStepIndex + 1, nightSteps.length)}/${nightSteps.length}`,
+      tone: 'night' as const,
+    },
+    {
+      label: '🌤',
+      value: String(nightResolutionPreview.finalEliminated.length),
+      tone: nightResolutionPreview.finalEliminated.length > 0 ? 'day' as const : 'success' as const,
+    },
+  ];
 
   const resetLocalState = () => {
     setWolfVictim('');
@@ -670,14 +686,67 @@ export default function NightPhase() {
   };
 
   return (
-    <div className="night-phase" data-testid="night-phase">
-      <div className="night-header">
-        <span className="phase-icon">&#127769;</span>
-        <div>
-          <h2>{t.night.title(round)}</h2>
-          <p className="night-subtitle">{t.night.subtitle}</p>
+    <ActionSurface
+      phase="night"
+      title={t.night.title(round)}
+      subtitle={t.night.subtitle}
+      metrics={metrics}
+      className="night-phase"
+      quickPanel={
+        <div className="gm-quick-panel">
+          <div className="gm-quick-panel__header">
+            <strong>{currentRole ? `${currentRole.emoji} ${currentRoleName}` : t.night.nightEnds}</strong>
+          </div>
+          <div className="gm-quick-panel__stack">
+            {currentNightStepIndex > 0 && (
+              <button className="btn btn-ghost btn-sm" onClick={handleBackStep}>
+                {t.night.goBack}
+              </button>
+            )}
+            {!allStepsDone && currentNightStepIndex + 1 < nightSteps.length && (
+              <span className="gm-quick-panel__hint">
+                {ROLE_MAP[nightSteps[currentNightStepIndex + 1]?.roleId]?.emoji}{' '}
+                {ROLE_MAP[nightSteps[currentNightStepIndex + 1]?.roleId]
+                  ? getRoleName(ROLE_MAP[nightSteps[currentNightStepIndex + 1].roleId], language)
+                  : ''}
+              </span>
+            )}
+          </div>
         </div>
-      </div>
+      }
+      footer={
+        !allStepsDone ? (
+          <div className="sticky-action-bar">
+            <button
+              className="btn btn-primary btn-large"
+              data-testid="night-next"
+              onClick={handleCompleteStep}
+              disabled={!canCompleteStep}
+            >
+              &#9989; Done &mdash; Next
+            </button>
+          </div>
+        ) : (
+          <div className="sticky-action-bar sticky-action-bar--split">
+            <button
+              className="btn btn-ghost"
+              onClick={handleBackStep}
+              disabled={currentNightStepIndex <= 0}
+            >
+              {t.night.goBack}
+            </button>
+            <button
+              className="btn btn-primary btn-large"
+              data-testid="reveal-day"
+              onClick={applyNightResults}
+            >
+              {t.night.revealDay}
+            </button>
+          </div>
+        )
+      }
+    >
+      <div data-testid="night-phase">
 
       {round === 1 && passiveReminderRoles.length > 0 && (
         <div className="gm-checklist" data-testid="passive-checklist">
@@ -745,20 +814,12 @@ export default function NightPhase() {
       {!allStepsDone ? (
         <>
           {renderStepContent()}
-          <button
-            className="btn btn-primary btn-large"
-            data-testid="night-next"
-            onClick={handleCompleteStep}
-            disabled={!canCompleteStep}
-          >
-            &#9989; Done &mdash; Next
-          </button>
         </>
       ) : (
         <div className="night-summary">
-          <h3>&#127749; Night ends</h3>
+          <h3>{t.night.nightEnds}</h3>
           {nightResolutionPreview.finalEliminated.length === 0 ? (
-            <p>No one was eliminated tonight. &#128570;</p>
+            <p>{t.night.noElim}</p>
           ) : (
             <p>
               {t.night.eliminated}{' '}
@@ -769,24 +830,30 @@ export default function NightPhase() {
               </strong>
             </p>
           )}
-          <div className="night-actions summary-actions">
-            <button
-              className="btn btn-ghost"
-              onClick={handleBackStep}
-              disabled={currentNightStepIndex <= 0}
-            >
-              {t.night.goBack}
-            </button>
-            <button
-              className="btn btn-primary btn-large"
-              data-testid="reveal-day"
-              onClick={applyNightResults}
-            >
-              {t.night.revealDay}
-            </button>
-          </div>
+          {!!currentProtectedPlayerId && (
+            <p className="night-summary-note">
+              🛡️ {allPlayers.find((player) => player.id === currentProtectedPlayerId)?.name}
+            </p>
+          )}
+          {(nightResolutionPreview.knightLog || nightResolutionPreview.loversLog) && (
+            <div className="resolution-list">
+              {nightResolutionPreview.knightLog && (
+                <div className="resolution-item resolution-item--chain">
+                  <strong>⚔️</strong>
+                  <p>{nightResolutionPreview.knightLog}</p>
+                </div>
+              )}
+              {nightResolutionPreview.loversLog && (
+                <div className="resolution-item resolution-item--chain">
+                  <strong>💘</strong>
+                  <p>{nightResolutionPreview.loversLog}</p>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
-    </div>
+      </div>
+    </ActionSurface>
   );
 }

--- a/src/components/Game/PlayerCard.tsx
+++ b/src/components/Game/PlayerCard.tsx
@@ -1,4 +1,4 @@
-
+import { useMemo } from 'react';
 import { useGameStore } from '../../store/gameStore';
 import { ROLE_MAP, getRoleName, getRoleTexts } from '../../data/roles';
 import { useI18n } from '../../i18n';
@@ -11,16 +11,31 @@ interface Props {
 
 export default function PlayerCard({ playerId, showRole = false }: Props) {
   const { language, t } = useI18n();
-  const player = useGameStore((s) => s.players.find((p) => p.id === playerId));
+  const player = useGameStore((s) => s.players.find((candidate) => candidate.id === playerId));
+  const status = useGameStore((s) => s.playerStatuses[playerId]);
   const eliminatePlayer = useGameStore((s) => s.eliminatePlayer);
   const electMayor = useGameStore((s) => s.electMayor);
+  const toggleRoleReveal = useGameStore((s) => s.toggleRoleReveal);
 
-  if (!player) return null;
-
-  const role = ROLE_MAP[player.roleId];
+  const role = player ? ROLE_MAP[player.roleId] : null;
   const roleTexts = role ? getRoleTexts(role, language) : null;
   const roleName = role ? getRoleName(role, language) : '';
-  const shouldShowRole = showRole;
+  const shouldShowRole = showRole || status?.revealed;
+
+  const statusBadges = useMemo(
+    () =>
+      [
+        status?.protected && '🛡️',
+        status?.cursed && '🦅',
+        status?.enchanted && '🎶',
+        status?.infected && '🦠',
+        status?.noVote && '🚫',
+        status?.transformed && '🐺',
+      ].filter(Boolean) as string[],
+    [status]
+  );
+
+  if (!player || !role) return null;
 
   return (
     <div
@@ -28,27 +43,41 @@ export default function PlayerCard({ playerId, showRole = false }: Props) {
         player.isMayor ? 'mayor' : ''
       } ${player.isLover ? 'lover' : ''}`}
     >
-      <div className="player-card-header">
-        <span className="player-emoji">{player.isAlive ? '🙂' : '💀'}</span>
-        <span className="player-card-name">{player.name}</span>
-        <div className="player-badges">
-          {player.isMayor && <span className="badge badge-mayor">{t.playerCard.mayor}</span>}
-          {player.isLover && <span className="badge badge-lover">{t.playerCard.lover}</span>}
+      <div className="player-card-main">
+        <div className="player-card-header">
+          <span className="player-emoji">{player.isAlive ? '🙂' : '💀'}</span>
+          <div className="player-card-identity">
+            <span className="player-card-name">{player.name}</span>
+            <div className="player-badges">
+              {player.isMayor && <span className="badge badge-mayor">{t.playerCard.mayor}</span>}
+              {player.isLover && <span className="badge badge-lover">{t.playerCard.lover}</span>}
+              {statusBadges.map((badge) => (
+                <span key={badge} className="badge badge-status">{badge}</span>
+              ))}
+            </div>
+          </div>
         </div>
-      </div>
 
-      {shouldShowRole && role && (
-        <div className={`player-role camp-${role.camp}`}>
-          <span>{role.emoji}</span>
-          <span>{roleName}</span>
-          {roleTexts?.revealTrigger && (
-            <div className="reveal-trigger">⚡ {roleTexts.revealTrigger}</div>
-          )}
-        </div>
-      )}
+        {shouldShowRole && (
+          <div className={`player-role camp-${role.camp}`}>
+            <span>{role.emoji}</span>
+            <span>{roleName}</span>
+            {roleTexts?.revealTrigger && (
+              <div className="reveal-trigger">⚡ {roleTexts.revealTrigger}</div>
+            )}
+          </div>
+        )}
+      </div>
 
       {player.isAlive && (
         <div className="player-actions">
+          <button
+            className="btn btn-sm btn-ghost"
+            onClick={() => toggleRoleReveal(player.id)}
+            title={t.playerCard.revealTitle}
+          >
+            {status?.revealed ? t.playerCard.hideRole : t.playerCard.revealRole}
+          </button>
           {!player.isMayor && (
             <button
               className="btn btn-sm btn-ghost"

--- a/src/components/Setup/SetupScreen.tsx
+++ b/src/components/Setup/SetupScreen.tsx
@@ -1,6 +1,7 @@
-import { useState, useCallback } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useGameStore } from '../../store/gameStore';
 import { SETUP_ROLE_IDS, SETUP_ROLES, getRoleName, getRoleTexts } from '../../data/roles';
+import ActionSurface from '../Shared/ActionSurface';
 import RoleReference from '../Roles/RoleReference';
 import LanguageToggle from '../LanguageToggle';
 import QuickGuide from './QuickGuide';
@@ -12,121 +13,219 @@ const MAX_PLAYERS = 20;
 const RULEBOOK_URL =
   'https://media.play-in.com/pdf/rules_games/best_of__les_loups-garous_de_thiercelieux_regles_fr.pdf';
 
+const ADVANCED_ROLE_IDS = new Set([
+  'white_werewolf',
+  'pied_piper',
+  'infect_pere',
+  'big_bad_wolf',
+  'wolf_dog',
+  'wild_child',
+  'village_idiot',
+  'scapegoat',
+  'raven',
+  'fox',
+  'cupid',
+]);
+
+function createSeatIds(count: number) {
+  return Array.from({ length: count }, (_, index) => `p${index}`);
+}
+
 export default function SetupScreen() {
   const { language, t } = useI18n();
   const setSetup = useGameStore((s) => s.setSetup);
   const startGame = useGameStore((s) => s.startGame);
+  const savedSessions = useGameStore((s) => s.savedSessions);
+  const saveNamedSession = useGameStore((s) => s.saveNamedSession);
+  const loadNamedSession = useGameStore((s) => s.loadNamedSession);
+  const deleteNamedSession = useGameStore((s) => s.deleteNamedSession);
+  const setUiMode = useGameStore((s) => s.setUiMode);
 
   const [tab, setTab] = useState<'setup' | 'roles' | 'guide'>('setup');
   const [playerCount, setPlayerCount] = useState(6);
   const [playerNames, setPlayerNames] = useState<string[]>(
-    Array.from({ length: 6 }, (_, i) => t.setup.playerNamePlaceholder(i + 1))
+    Array.from({ length: 6 }, (_, index) => t.setup.playerNamePlaceholder(index + 1))
   );
-  const [roleAssignment, setRoleAssignment] = useState<string[]>(
-    Array(6).fill('villager')
-  );
+  const [roleAssignment, setRoleAssignment] = useState<string[]>(Array(6).fill('villager'));
+  const [seatOrder, setSeatOrder] = useState<string[]>(createSeatIds(6));
   const [discussionTime, setDiscussionTime] = useState(180);
   const [optionalRules, setOptionalRules] = useState<Record<string, boolean>>({});
+  const [sessionName, setSessionName] = useState('');
+
+  const switchTab = useCallback(
+    (nextTab: 'setup' | 'roles' | 'guide') => {
+      setTab(nextTab);
+      setUiMode(nextTab === 'setup' ? 'prepare' : 'reference');
+    },
+    [setUiMode]
+  );
 
   const handlePlayerCountChange = useCallback(
     (count: number) => {
-      const c = Math.min(MAX_PLAYERS, Math.max(MIN_PLAYERS, count));
-      setPlayerCount(c);
+      const nextCount = Math.min(MAX_PLAYERS, Math.max(MIN_PLAYERS, count));
+      setPlayerCount(nextCount);
       setPlayerNames((prev) => {
         const next = [...prev];
-        while (next.length < c) next.push(t.setup.playerNamePlaceholder(next.length + 1));
-        return next.slice(0, c);
+        while (next.length < nextCount) next.push(t.setup.playerNamePlaceholder(next.length + 1));
+        return next.slice(0, nextCount);
       });
       setRoleAssignment((prev) => {
         const next = [...prev];
-        while (next.length < c) next.push('villager');
-        return next.slice(0, c);
+        while (next.length < nextCount) next.push('villager');
+        return next.slice(0, nextCount);
+      });
+      setSeatOrder((prev) => {
+        const nextIds = createSeatIds(nextCount);
+        const preserved = prev.filter((id) => nextIds.includes(id));
+        return [...preserved, ...nextIds.filter((id) => !preserved.includes(id))];
       });
     },
     [t]
   );
 
-  const handleNameChange = (i: number, value: string) => {
+  const handleNameChange = (index: number, value: string) => {
     setPlayerNames((prev) => {
       const next = [...prev];
-      next[i] = value;
+      next[index] = value;
       return next;
     });
   };
 
-  const handleRoleChange = (i: number, roleId: string) => {
+  const handleRoleChange = (index: number, roleId: string) => {
     setRoleAssignment((prev) => {
       const next = [...prev];
-      next[i] = SETUP_ROLE_IDS.has(roleId) ? roleId : 'villager';
+      next[index] = SETUP_ROLE_IDS.has(roleId) ? roleId : 'villager';
+      return next;
+    });
+  };
+
+  const moveSeat = (seatId: string, direction: 'up' | 'down') => {
+    setSeatOrder((prev) => {
+      const fromIndex = prev.indexOf(seatId);
+      const toIndex = fromIndex + (direction === 'up' ? -1 : 1);
+      if (fromIndex === -1 || toIndex < 0 || toIndex >= prev.length) return prev;
+      const next = [...prev];
+      const [moved] = next.splice(fromIndex, 1);
+      next.splice(toIndex, 0, moved);
       return next;
     });
   };
 
   const applyStarterPreset = useCallback(
     (preset: (typeof t.quickGuide.starterSets)[number]) => {
-      const clamped = Math.min(MAX_PLAYERS, Math.max(MIN_PLAYERS, preset.players));
-      setPlayerCount(clamped);
+      const nextCount = Math.min(MAX_PLAYERS, Math.max(MIN_PLAYERS, preset.players));
+      setPlayerCount(nextCount);
       setPlayerNames((prev) => {
         const next = [...prev];
-        while (next.length < clamped) next.push(t.setup.playerNamePlaceholder(next.length + 1));
-        return next.slice(0, clamped);
+        while (next.length < nextCount) next.push(t.setup.playerNamePlaceholder(next.length + 1));
+        return next.slice(0, nextCount);
       });
       setRoleAssignment(() => {
-        const next = preset.roles.slice(0, clamped);
-        while (next.length < clamped) next.push('villager');
+        const next = preset.roles.slice(0, nextCount);
+        while (next.length < nextCount) next.push('villager');
         return next.map((id: string) => (SETUP_ROLE_IDS.has(id) ? id : 'villager'));
       });
+      setSeatOrder(createSeatIds(nextCount));
       setOptionalRules({});
     },
     [t]
   );
 
-  // Tally roles assigned
+  const orderedSeats = useMemo(
+    () =>
+      seatOrder.map((seatId) => {
+        const index = Number(seatId.replace('p', ''));
+        return {
+          seatId,
+          index,
+          name: playerNames[index] ?? t.setup.playerNamePlaceholder(index + 1),
+          roleId: roleAssignment[index] ?? 'villager',
+        };
+      }),
+    [playerNames, roleAssignment, seatOrder, t]
+  );
+
   const roleCounts: Record<string, number> = {};
-  roleAssignment.slice(0, playerCount).forEach((r) => {
-    const roleId = SETUP_ROLE_IDS.has(r) ? r : 'villager';
-    roleCounts[roleId] = (roleCounts[roleId] ?? 0) + 1;
+  roleAssignment.slice(0, playerCount).forEach((roleId) => {
+    const normalizedRoleId = SETUP_ROLE_IDS.has(roleId) ? roleId : 'villager';
+    roleCounts[normalizedRoleId] = (roleCounts[normalizedRoleId] ?? 0) + 1;
   });
 
-  // Validation
   const errors: string[] = [];
   Object.entries(roleCounts).forEach(([id, count]) => {
-    const def = SETUP_ROLES.find((r) => r.id === id);
-    if (!def) return;
-    const roleLabel = getRoleName(def, language);
-    if (count > def.maxCount)
-      errors.push(t.setup.errors.tooMany(roleLabel, def.maxCount));
-    if (count < def.minCount)
-      errors.push(t.setup.errors.notEnough(roleLabel, def.minCount));
+    const definition = SETUP_ROLES.find((role) => role.id === id);
+    if (!definition) return;
+    const roleLabel = getRoleName(definition, language);
+    if (count > definition.maxCount) errors.push(t.setup.errors.tooMany(roleLabel, definition.maxCount));
+    if (count < definition.minCount) errors.push(t.setup.errors.notEnough(roleLabel, definition.minCount));
   });
-  const wolfSideCount = (roleCounts['werewolf'] ?? 0) + (roleCounts['white_werewolf'] ?? 0);
-  if (wolfSideCount === 0)
-    errors.push(t.setup.errors.needWolf);
-  const sistersDef = SETUP_ROLES.find((r) => r.id === 'soeurs');
-  if (sistersDef && (roleCounts['soeurs'] ?? 0) === 1)
+
+  const wolfSideCount =
+    (roleCounts['werewolf'] ?? 0) +
+    (roleCounts['white_werewolf'] ?? 0) +
+    (roleCounts['big_bad_wolf'] ?? 0) +
+    (roleCounts['infect_pere'] ?? 0);
+  if (wolfSideCount === 0) errors.push(t.setup.errors.needWolf);
+
+  const sistersDef = SETUP_ROLES.find((role) => role.id === 'soeurs');
+  if (sistersDef && (roleCounts['soeurs'] ?? 0) === 1) {
     errors.push(t.setup.errors.pairRequired(getRoleName(sistersDef, language)));
+  }
+
+  const infoRoleCount =
+    (roleCounts['seer'] ?? 0) +
+    (roleCounts['protector'] ?? 0) +
+    (roleCounts['witch'] ?? 0) +
+    (roleCounts['bear_tamer'] ?? 0) +
+    (roleCounts['fox'] ?? 0);
+  const advancedRoleCount = Object.entries(roleCounts)
+    .filter(([id]) => ADVANCED_ROLE_IDS.has(id))
+    .reduce((sum, [, count]) => sum + count, 0);
+
+  const balanceNotes = [
+    wolfSideCount < Math.ceil(playerCount / 6) && t.setup.balanceWarnings.needPressure,
+    infoRoleCount === 0 && t.setup.balanceWarnings.needInformation,
+    advancedRoleCount >= Math.ceil(playerCount / 3) && t.setup.balanceWarnings.tooChaotic,
+  ].filter(Boolean) as string[];
 
   const canStart = errors.length === 0;
+  const optionalRoleRules = SETUP_ROLES.filter((role) => role.optionalRule);
 
   const handleStart = () => {
     if (!canStart) return;
-    const sanitizedRoleIds = roleAssignment
-      .slice(0, playerCount)
-      .map((id) => (SETUP_ROLE_IDS.has(id) ? id : 'villager'));
-    const allowedOptionalRules = Object.fromEntries(
-      Object.entries(optionalRules).filter(([id]) => SETUP_ROLE_IDS.has(id))
-    );
     setSetup({
       playerNames: playerNames.slice(0, playerCount),
-      roleIds: sanitizedRoleIds,
+      roleIds: roleAssignment
+        .slice(0, playerCount)
+        .map((roleId) => (SETUP_ROLE_IDS.has(roleId) ? roleId : 'villager')),
       discussionTime,
-      optionalRules: allowedOptionalRules,
+      optionalRules: Object.fromEntries(
+        Object.entries(optionalRules).filter(([id]) => SETUP_ROLE_IDS.has(id))
+      ),
+      seatOrder: seatOrder.slice(0, playerCount),
     });
     startGame();
   };
 
-  // Role distribution helper: roles that have optional rules
-  const optionalRoleRules = SETUP_ROLES.filter((r) => r.optionalRule);
+  const handleSaveSession = () => {
+    const name = sessionName.trim() || t.setup.defaultSessionName(playerCount);
+    setSetup({
+      playerNames: playerNames.slice(0, playerCount),
+      roleIds: roleAssignment.slice(0, playerCount),
+      discussionTime,
+      optionalRules,
+      seatOrder: seatOrder.slice(0, playerCount),
+    });
+    saveNamedSession(name);
+    setSessionName('');
+  };
+
+  const metrics = [
+    { label: t.setup.metrics.players, value: String(playerCount), tone: 'neutral' as const },
+    { label: t.setup.metrics.wolfPressure, value: String(wolfSideCount), tone: wolfSideCount > 0 ? 'danger' as const : 'neutral' as const },
+    { label: t.setup.metrics.infoRoles, value: String(infoRoleCount), tone: infoRoleCount > 0 ? 'success' as const : 'neutral' as const },
+    { label: t.setup.metrics.chaos, value: String(advancedRoleCount), tone: advancedRoleCount > 1 ? 'day' as const : 'neutral' as const },
+  ];
 
   return (
     <div className="setup-screen">
@@ -142,6 +241,7 @@ export default function SetupScreen() {
           <span aria-hidden="true">📖</span>
         </a>
       </div>
+
       <div className="setup-header">
         <span className="moon-icon">🌕</span>
         <h1>{t.appTitle}</h1>
@@ -151,171 +251,284 @@ export default function SetupScreen() {
       <div className="setup-tabs">
         <button
           className={`tab-btn ${tab === 'setup' ? 'active' : ''}`}
-          onClick={() => setTab('setup')}
+          onClick={() => switchTab('setup')}
           data-testid="setup-tab-setup"
         >
-          ⚙️ {t.tabs.setup}
+          ⚙️ {t.setup.prepareTab}
         </button>
         <button
           className={`tab-btn ${tab === 'roles' ? 'active' : ''}`}
-          onClick={() => setTab('roles')}
+          onClick={() => switchTab('roles')}
           data-testid="setup-tab-roles"
         >
           📚 {t.tabs.roles}
         </button>
         <button
           className={`tab-btn ${tab === 'guide' ? 'active' : ''}`}
-          onClick={() => setTab('guide')}
+          onClick={() => switchTab('guide')}
           data-testid="setup-tab-guide"
         >
-          {language === 'fr' ? '📘 Guide rapide' : '📘 Quick Guide'}
+          📘 {t.quickGuide.title}
         </button>
       </div>
 
       {tab === 'setup' ? (
-        <div data-testid="setup-main-tab">
-          {/* Player Count */}
-          <section className="setup-section">
-            <h2>👥 {t.setup.numberOfPlayers}</h2>
-            <div className="player-count-row">
+        <ActionSurface
+          phase="prepare"
+          title={t.setup.prepareTitle}
+          subtitle={t.setup.prepareSubtitle}
+          metrics={metrics}
+          className="setup-surface"
+          footer={
+            <div className="setup-footer-actions">
+              <button className="btn btn-ghost" onClick={handleSaveSession}>
+                {t.setup.saveSession}
+              </button>
               <button
-                className="count-btn"
-                onClick={() => handlePlayerCountChange(playerCount - 1)}
-                disabled={playerCount <= MIN_PLAYERS}
+                className="start-btn"
+                data-testid="start-game"
+                onClick={handleStart}
+                disabled={!canStart}
               >
-                −
-              </button>
-              <span className="count-display">{playerCount}</span>
-              <button
-                className="count-btn"
-                onClick={() => handlePlayerCountChange(playerCount + 1)}
-                disabled={playerCount >= MAX_PLAYERS}
-              >
-                +
+                {t.setup.startGame}
               </button>
             </div>
-          </section>
-
-          {/* Player Names & Role Assignment */}
-          <section className="setup-section">
-            <div className="setup-section-header">
-              <h2>🃏 {t.setup.assignRoles}</h2>
-              <button className="btn btn-ghost btn-sm" onClick={() => setTab('roles')}>
-                📚 {t.setup.viewRoleDescriptions}
-              </button>
-            </div>
-            <div className="player-list">
-              {Array.from({ length: playerCount }, (_, i) => (
-                <div key={i} className="player-row" data-testid={`player-row-${i}`}>
-                  <span className="player-num">{i + 1}</span>
-                  <input
-                    className="player-name-input"
-                    value={playerNames[i] ?? ''}
-                    onChange={(e) => handleNameChange(i, e.target.value)}
-                    placeholder={t.setup.playerNamePlaceholder(i + 1)}
-                  />
-                  <select
-                    className="role-select"
-                    data-testid="role-select"
-                    value={roleAssignment[i] ?? 'villager'}
-                    onChange={(e) => handleRoleChange(i, e.target.value)}
-                  >
-                    {SETUP_ROLES.map((r) => (
-                      <option key={r.id} value={r.id}>
-                        {r.emoji} {getRoleName(r, language)}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              ))}
-            </div>
-          </section>
-
-          {/* Role Summary */}
-          <section className="setup-section">
-            <h2>📊 {t.setup.roleSummary}</h2>
-            <div className="role-summary">
-              {Object.entries(roleCounts).map(([id, count]) => {
-                const def = SETUP_ROLES.find((r) => r.id === id);
-                if (!def) return null;
-                return (
-                  <div key={id} className={`role-badge camp-${def.camp}`}>
-                    {def.emoji} {getRoleName(def, language)} ×{count}
-                  </div>
-                );
-              })}
-            </div>
-          </section>
-
-          {/* Discussion Timer */}
-          <section className="setup-section">
-            <h2>⏱️ {t.setup.discussionTimer}</h2>
-            <div className="timer-config">
-              <button
-                className="count-btn"
-                onClick={() => setDiscussionTime((t) => Math.max(30, t - 30))}
-              >
-                −30s
-              </button>
-              <span className="count-display">
-                {Math.floor(discussionTime / 60)}:{String(discussionTime % 60).padStart(2, '0')}
-              </span>
-              <button
-                className="count-btn"
-                onClick={() => setDiscussionTime((t) => Math.min(600, t + 30))}
-              >
-                +30s
-              </button>
-            </div>
-          </section>
-
-          {/* Optional Rules */}
-          {optionalRoleRules.length > 0 && (
-            <section className="setup-section">
-              <h2>⚙️ {t.setup.optionalRules}</h2>
-              {optionalRoleRules.map((r) => (
-                <label key={r.id} className="optional-rule">
-                  <input
-                    type="checkbox"
-                    checked={!!optionalRules[r.id]}
-                    onChange={(e) =>
-                      setOptionalRules((prev) => ({ ...prev, [r.id]: e.target.checked }))
-                    }
-                  />
-                  <span>
-                    {r.emoji} <strong>{getRoleName(r, language)}</strong>: {getRoleTexts(r, language).optionalRule}
-                  </span>
-                </label>
-              ))}
+          }
+        >
+          <div data-testid="setup-main-tab" className="setup-main-grid">
+            <section className="setup-section setup-section--hero">
+              <div className="setup-section-header">
+                <h2>{t.setup.quickStarts}</h2>
+                <p className="setup-kicker">{t.quickGuide.startersSubtitle}</p>
+              </div>
+              <QuickGuide onApplyPreset={applyStarterPreset} />
             </section>
-          )}
 
-          {/* Errors */}
-          {errors.length > 0 && (
-            <div className="setup-errors">
-              {errors.map((e, i) => (
-                <div key={i} className="error-msg">
-                  ⚠️ {e}
+            <section className="setup-section">
+              <div className="setup-section-header">
+                <h2>{t.setup.savedSessionsTitle}</h2>
+                <span className="setup-kicker">{t.setup.resumeHint}</span>
+              </div>
+              <div className="session-save-row">
+                <input
+                  className="player-name-input"
+                  value={sessionName}
+                  onChange={(event) => setSessionName(event.target.value)}
+                  placeholder={t.setup.sessionNamePlaceholder}
+                  data-testid="session-name-input"
+                />
+                <button className="btn btn-ghost" onClick={handleSaveSession} data-testid="save-session">
+                  {t.setup.saveSession}
+                </button>
+              </div>
+              {savedSessions.length === 0 ? (
+                <p className="setup-empty">{t.setup.noSavedSessions}</p>
+              ) : (
+                <div className="saved-session-list">
+                  {savedSessions.map((session) => (
+                    <div key={session.id} className="saved-session-card" data-testid="saved-session-card">
+                      <div>
+                        <strong>{session.name}</strong>
+                        <p>{new Date(session.updatedAt).toLocaleString(language === 'fr' ? 'fr-FR' : 'en-US')}</p>
+                      </div>
+                      <div className="saved-session-actions">
+                        <button className="btn btn-ghost btn-sm" onClick={() => loadNamedSession(session.id)}>
+                          {t.setup.loadSession}
+                        </button>
+                        <button className="btn btn-danger btn-sm" onClick={() => deleteNamedSession(session.id)}>
+                          {t.setup.deleteSession}
+                        </button>
+                      </div>
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
-          )}
+              )}
+            </section>
 
-          <button
-            className="start-btn"
-            data-testid="start-game"
-            onClick={handleStart}
-            disabled={!canStart}
-          >
-            {t.setup.startGame}
-          </button>
-        </div>
+            <section className="setup-section">
+              <h2>👥 {t.setup.numberOfPlayers}</h2>
+              <div className="player-count-row">
+                <button
+                  className="count-btn"
+                  onClick={() => handlePlayerCountChange(playerCount - 1)}
+                  disabled={playerCount <= MIN_PLAYERS}
+                >
+                  −
+                </button>
+                <span className="count-display">{playerCount}</span>
+                <button
+                  className="count-btn"
+                  onClick={() => handlePlayerCountChange(playerCount + 1)}
+                  disabled={playerCount >= MAX_PLAYERS}
+                >
+                  +
+                </button>
+              </div>
+            </section>
+
+            <section className="setup-section">
+              <div className="setup-section-header">
+                <h2>🃏 {t.setup.assignRoles}</h2>
+                <button className="btn btn-ghost btn-sm" onClick={() => switchTab('roles')}>
+                  📚 {t.setup.viewRoleDescriptions}
+                </button>
+              </div>
+              <div className="player-list">
+                {Array.from({ length: playerCount }, (_, index) => (
+                  <div key={index} className="player-row" data-testid={`player-row-${index}`}>
+                    <span className="player-num">{index + 1}</span>
+                    <input
+                      className="player-name-input"
+                      value={playerNames[index] ?? ''}
+                      onChange={(event) => handleNameChange(index, event.target.value)}
+                      placeholder={t.setup.playerNamePlaceholder(index + 1)}
+                    />
+                    <select
+                      className="role-select"
+                      data-testid="role-select"
+                      value={roleAssignment[index] ?? 'villager'}
+                      onChange={(event) => handleRoleChange(index, event.target.value)}
+                    >
+                      {SETUP_ROLES.map((role) => (
+                        <option key={role.id} value={role.id}>
+                          {role.emoji} {getRoleName(role, language)}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <section className="setup-section">
+              <div className="setup-section-header">
+                <h2>{t.setup.seatOrder}</h2>
+                <span className="setup-kicker">{t.setup.seatOrderHint}</span>
+              </div>
+              <div className="seat-order-list">
+                {orderedSeats.map((seat, index) => {
+                  const role = SETUP_ROLES.find((candidate) => candidate.id === seat.roleId);
+                  return (
+                    <div key={seat.seatId} className="seat-order-row" data-testid={`seat-order-row-${index}`}>
+                      <div>
+                        <strong>{index + 1}. {seat.name}</strong>
+                        <p>{role ? `${role.emoji} ${getRoleName(role, language)}` : seat.roleId}</p>
+                      </div>
+                      <div className="seat-order-actions">
+                        <button
+                          className="btn btn-ghost btn-sm"
+                          onClick={() => moveSeat(seat.seatId, 'up')}
+                          disabled={index === 0}
+                        >
+                          ↑
+                        </button>
+                        <button
+                          className="btn btn-ghost btn-sm"
+                          onClick={() => moveSeat(seat.seatId, 'down')}
+                          disabled={index === orderedSeats.length - 1}
+                        >
+                          ↓
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className="setup-section">
+              <h2>📊 {t.setup.roleSummary}</h2>
+              <div className="role-summary">
+                {Object.entries(roleCounts).map(([id, count]) => {
+                  const role = SETUP_ROLES.find((candidate) => candidate.id === id);
+                  if (!role) return null;
+                  return (
+                    <div key={id} className={`role-badge camp-${role.camp}`}>
+                      {role.emoji} {getRoleName(role, language)} ×{count}
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className="setup-section">
+              <div className="setup-section-header">
+                <h2>{t.setup.balanceTitle}</h2>
+                <span className="setup-kicker">
+                  {balanceNotes.length === 0 ? t.setup.balanceGood : t.setup.balanceNeedsAttention}
+                </span>
+              </div>
+              <div className="balance-notes">
+                {balanceNotes.length === 0 ? (
+                  <div className="balance-note balance-note--good">{t.setup.balanceGoodBody}</div>
+                ) : (
+                  balanceNotes.map((note) => (
+                    <div key={note} className="balance-note balance-note--warn">
+                      {note}
+                    </div>
+                  ))
+                )}
+              </div>
+            </section>
+
+            <section className="setup-section">
+              <h2>⏱️ {t.setup.discussionTimer}</h2>
+              <div className="timer-config">
+                <button
+                  className="count-btn"
+                  onClick={() => setDiscussionTime((time) => Math.max(30, time - 30))}
+                >
+                  −30s
+                </button>
+                <span className="count-display">
+                  {Math.floor(discussionTime / 60)}:{String(discussionTime % 60).padStart(2, '0')}
+                </span>
+                <button
+                  className="count-btn"
+                  onClick={() => setDiscussionTime((time) => Math.min(600, time + 30))}
+                >
+                  +30s
+                </button>
+              </div>
+            </section>
+
+            {optionalRoleRules.length > 0 && (
+              <section className="setup-section">
+                <h2>⚙️ {t.setup.optionalRules}</h2>
+                {optionalRoleRules.map((role) => (
+                  <label key={role.id} className="optional-rule">
+                    <input
+                      type="checkbox"
+                      checked={!!optionalRules[role.id]}
+                      onChange={(event) =>
+                        setOptionalRules((prev) => ({ ...prev, [role.id]: event.target.checked }))
+                      }
+                    />
+                    <span>
+                      {role.emoji} <strong>{getRoleName(role, language)}</strong>: {getRoleTexts(role, language).optionalRule}
+                    </span>
+                  </label>
+                ))}
+              </section>
+            )}
+
+            {errors.length > 0 && (
+              <div className="setup-errors">
+                {errors.map((error) => (
+                  <div key={error} className="error-msg">
+                    ⚠️ {error}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </ActionSurface>
       ) : tab === 'roles' ? (
         <section className="roles-tab-panel" data-testid="setup-roles-tab">
           <p className="roles-tab-hint">{t.setup.rolesTabHint}</p>
           <RoleReference />
           <div className="roles-tab-actions">
-            <button className="btn btn-primary btn-large" onClick={() => setTab('setup')}>
+            <button className="btn btn-primary btn-large" onClick={() => switchTab('setup')}>
               {t.setup.backToSetup}
             </button>
           </div>
@@ -325,7 +538,7 @@ export default function SetupScreen() {
           <p className="roles-tab-hint">{t.quickGuide.subtitle}</p>
           <QuickGuide onApplyPreset={applyStarterPreset} />
           <div className="roles-tab-actions">
-            <button className="btn btn-primary btn-large" onClick={() => setTab('setup')}>
+            <button className="btn btn-primary btn-large" onClick={() => switchTab('setup')}>
               {t.setup.backToSetup}
             </button>
           </div>

--- a/src/components/Shared/ActionSurface.tsx
+++ b/src/components/Shared/ActionSurface.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from 'react';
+
+interface MetricItem {
+  label: string;
+  value: string;
+  tone?: 'neutral' | 'night' | 'day' | 'danger' | 'success';
+}
+
+interface ActionSurfaceProps {
+  phase: 'prepare' | 'night' | 'day';
+  title: string;
+  subtitle?: string;
+  metrics?: MetricItem[];
+  quickPanel?: ReactNode;
+  footer?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+export default function ActionSurface({
+  phase,
+  title,
+  subtitle,
+  metrics = [],
+  quickPanel,
+  footer,
+  children,
+  className = '',
+}: ActionSurfaceProps) {
+  return (
+    <section className={`action-surface action-surface--${phase} ${className}`.trim()}>
+      <header className="action-surface__header">
+        <div>
+          <h2>{title}</h2>
+          {subtitle && <p className="action-surface__subtitle">{subtitle}</p>}
+        </div>
+      </header>
+
+      {metrics.length > 0 && (
+        <div className="action-surface__metrics">
+          {metrics.map((metric) => (
+            <div
+              key={`${metric.label}-${metric.value}`}
+              className={`action-surface__metric action-surface__metric--${metric.tone ?? 'neutral'}`}
+            >
+              <span className="action-surface__metric-label">{metric.label}</span>
+              <strong>{metric.value}</strong>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {quickPanel && <aside className="action-surface__quick-panel">{quickPanel}</aside>}
+
+      <div className="action-surface__body">{children}</div>
+
+      {footer && <footer className="action-surface__footer">{footer}</footer>}
+    </section>
+  );
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -8,6 +8,35 @@ interface Strings {
   rulebook: string;
   tabs: { setup: string; roles: string; game: string; log: string };
   setup: {
+    prepareTab: string;
+    prepareTitle: string;
+    prepareSubtitle: string;
+    quickStarts: string;
+    savedSessionsTitle: string;
+    resumeHint: string;
+    sessionNamePlaceholder: string;
+    saveSession: string;
+    noSavedSessions: string;
+    loadSession: string;
+    deleteSession: string;
+    seatOrder: string;
+    seatOrderHint: string;
+    balanceTitle: string;
+    balanceGood: string;
+    balanceNeedsAttention: string;
+    balanceGoodBody: string;
+    defaultSessionName: (count: number) => string;
+    metrics: {
+      players: string;
+      wolfPressure: string;
+      infoRoles: string;
+      chaos: string;
+    };
+    balanceWarnings: {
+      needPressure: string;
+      needInformation: string;
+      tooChaotic: string;
+    };
     numberOfPlayers: string;
     assignRoles: string;
     viewRoleDescriptions: string;
@@ -66,10 +95,27 @@ interface Strings {
     phaseChip: (phase: Phase, round: number) => string;
     alive: (count: number) => string;
     wolves: (count: number) => string;
+    unresolved: (count: number) => string;
     resetConfirm: string;
     reset: string;
+    undo: string;
+    privacyOn: string;
+    privacyOff: string;
+    privacyTitle: string;
+    privacyBody: string;
+    quickPanel: string;
     tabs: { game: string; roles: string; log: string };
     log: { title: string; empty: string };
+    recapTitle: string;
+    exportRecap: string;
+    endReason: string;
+    endReasons: {
+      village: string;
+      werewolves: (wolves: number, village: number) => string;
+      piedPiper: string;
+      whiteWerewolf: string;
+      angel: string;
+    };
     wins: {
       village: { title: string; body: string };
       werewolves: { title: string; body: string };
@@ -160,9 +206,17 @@ interface Strings {
   day: {
     title: (round: number) => string;
     subtitle: string;
+    metrics: {
+      alive: string;
+      pressure: string;
+      unresolved: string;
+      timer: string;
+    };
     dmView: { show: string; hide: string };
     bearSignal: (growls: boolean) => string;
     dmReminders: string;
+    resolutionTitle: string;
+    resolutionHint: string;
     piedPiperBar: (count: number, total: number) => string;
     piedPiperWins: string;
     infectedBar: string;
@@ -170,6 +224,16 @@ interface Strings {
     foxPowerLost: string;
     witchPotionsStatus: (healUsed: boolean, poisonUsed: boolean) => string;
     witchPotionsSpent: string;
+    voteAssistTitle: string;
+    voteAssistHint: string;
+    voteAssistEnable: string;
+    voteAssistDisable: string;
+    clearVotes: string;
+    totalVotes: (count: number) => string;
+    mayorPlusTwo: string;
+    noVote: string;
+    allowVote: string;
+    tieDetected: (names: string) => string;
     playersTitle: (alive: number) => string;
     tieResolutionTitle: string;
     tieResolutionHint: string;
@@ -197,8 +261,11 @@ interface Strings {
     lover: string;
     makeMayor: string;
     eliminate: string;
+    revealRole: string;
+    hideRole: string;
     mayorTitle: string;
     eliminateTitle: string;
+    revealTitle: string;
   };
   tieBreaker: {
     title: string;
@@ -262,6 +329,35 @@ const translations: Record<Language, Strings> = {
       log: 'Log',
     },
     setup: {
+      prepareTab: 'Prepare',
+      prepareTitle: 'Prepare The Table',
+      prepareSubtitle: 'Set seats, pressure, and chaos before the first night starts.',
+      quickStarts: 'Quick Starts',
+      savedSessionsTitle: 'Saved Sessions',
+      resumeHint: 'Resume a live table or save the current setup before launching.',
+      sessionNamePlaceholder: 'Session name',
+      saveSession: 'Save Session',
+      noSavedSessions: 'No saved sessions yet.',
+      loadSession: 'Load',
+      deleteSession: 'Delete',
+      seatOrder: 'Seat Order',
+      seatOrderHint: 'Arrange seats here so adjacency roles stay reliable.',
+      balanceTitle: 'Balance Feedback',
+      balanceGood: 'Ready',
+      balanceNeedsAttention: 'Needs attention',
+      balanceGoodBody: 'This lineup has wolves, information, and manageable chaos for a live table.',
+      defaultSessionName: (count: number) => `Table for ${count} players`,
+      metrics: {
+        players: 'Players',
+        wolfPressure: 'Wolf Pressure',
+        infoRoles: 'Info Roles',
+        chaos: 'Chaos',
+      },
+      balanceWarnings: {
+        needPressure: 'Add more wolf-side pressure or the village may snowball too easily.',
+        needInformation: 'Add at least one information or protection role so the village has direction.',
+        tooChaotic: 'This setup stacks many swingy roles. Expect a high-variance game.',
+      },
       numberOfPlayers: 'Number of Players',
       assignRoles: 'Assign Roles',
       viewRoleDescriptions: 'Roles',
@@ -352,16 +448,34 @@ const translations: Record<Language, Strings> = {
         `${phase === 'night' ? '🌙 Night' : '☀️ Day'} — Round ${round}`,
       alive: (count: number) => `🫀 ${count} alive`,
       wolves: (count: number) => `🐺 ${count} wolves`,
+      unresolved: (count: number) => `📌 ${count} unresolved`,
       resetConfirm: 'Reset game and return to setup?',
       reset: '🏠 Setup',
+      undo: '↩ Undo',
+      privacyOn: '🙈 Privacy',
+      privacyOff: '👁 Reveal',
+      privacyTitle: 'Privacy mode is active',
+      privacyBody: 'Use this when passing the phone or hiding live GM information.',
+      quickPanel: 'GM Quick Panel',
       tabs: {
-        game: '🎮 Game',
-        roles: '📚 Roles',
+        game: '🎮 Run',
+        roles: '📚 Reference',
         log: '📜 Log',
       },
       log: {
         title: '📜 Game Log',
         empty: 'No events yet.',
+      },
+      recapTitle: 'Session Recap',
+      exportRecap: 'Export Recap',
+      endReason: 'Why the game ended',
+      endReasons: {
+        village: 'The village wins because no pack wolves and no White Werewolf remain alive.',
+        werewolves: (wolves: number, village: number) =>
+          `The wolves reached parity with ${wolves} wolf-side players against ${village} village-side players.`,
+        piedPiper: 'The Pied Piper wins because every other living player is enchanted.',
+        whiteWerewolf: 'The White Werewolf wins because they are the sole survivor.',
+        angel: 'The Angel wins because they were the first execution on Day 1.',
       },
       wins: {
         village: { title: 'Village Wins!', body: 'All werewolves have been eliminated.' },
@@ -463,10 +577,18 @@ const translations: Record<Language, Strings> = {
     day: {
       title: (round: number) => `Day Phase — Round ${round}`,
       subtitle: 'All players open their eyes.',
+      metrics: {
+        alive: 'Alive',
+        pressure: 'Wolf Pressure',
+        unresolved: 'Unresolved',
+        timer: 'Timer',
+      },
       dmView: { show: '👁 DM View', hide: '🙈 Hide Roles' },
       bearSignal: (growls: boolean) =>
         growls ? '🐻 Bear signal: 🔊 GROWLS (wolf nearby!)' : '🐻 Bear signal: 🤫 Silent',
       dmReminders: '📋 DM Reminders',
+      resolutionTitle: 'Dawn Resolution Queue',
+      resolutionHint: 'Resolve deaths, chains, and public reminders in order before the vote settles.',
       piedPiperBar: (count: number, total: number) =>
         `🎶 Pied Piper enchanted: ${count} / ${total} players`,
       piedPiperWins: '⭐ PIED PIPER WINS!',
@@ -476,6 +598,16 @@ const translations: Record<Language, Strings> = {
       witchPotionsStatus: (healUsed: boolean, poisonUsed: boolean) =>
         `🧙‍♀️ Witch potions — Healing: ${healUsed ? 'USED' : 'available'}, Death: ${poisonUsed ? 'USED' : 'available'}.`,
       witchPotionsSpent: '🧙‍♀️ Witch has no potions left (skip future Witch wake-ups).',
+      voteAssistTitle: 'Vote Assist',
+      voteAssistHint: 'Track the table vote here, while keeping manual overrides available.',
+      voteAssistEnable: 'Start Vote Assist',
+      voteAssistDisable: 'Hide Vote Assist',
+      clearVotes: 'Clear Votes',
+      totalVotes: (count: number) => `Total against: ${count}`,
+      mayorPlusTwo: 'Mayor +2',
+      noVote: 'No vote',
+      allowVote: 'Allow vote',
+      tieDetected: (names: string) => `Tie detected between: ${names}`,
       playersTitle: (alive: number) => `👥 Players (${alive} alive)`,
       tieResolutionTitle: '⚖️ Tie Resolution',
       tieResolutionHint: 'Use this only when the real-table vote ends in a tie.',
@@ -505,8 +637,11 @@ const translations: Record<Language, Strings> = {
       lover: '💘 Lover',
       makeMayor: '🎖️ Mayor',
       eliminate: '☠️ Elim.',
+      revealRole: '👁 Reveal',
+      hideRole: '🙈 Hide',
       mayorTitle: 'Make Mayor',
       eliminateTitle: 'Eliminate',
+      revealTitle: 'Toggle role reveal',
     },
     tieBreaker: {
       title: '⚖️ Tie-Breaker',
@@ -544,6 +679,35 @@ const translations: Record<Language, Strings> = {
       log: 'Journal',
     },
     setup: {
+      prepareTab: 'Préparer',
+      prepareTitle: 'Préparer La Table',
+      prepareSubtitle: 'Réglez les sièges, la pression des loups et le niveau de chaos avant la première nuit.',
+      quickStarts: 'Démarrages rapides',
+      savedSessionsTitle: 'Sessions enregistrées',
+      resumeHint: 'Reprenez une table en cours ou sauvegardez votre préparation.',
+      sessionNamePlaceholder: 'Nom de la session',
+      saveSession: 'Enregistrer',
+      noSavedSessions: 'Aucune session enregistrée.',
+      loadSession: 'Charger',
+      deleteSession: 'Supprimer',
+      seatOrder: 'Ordre des sièges',
+      seatOrderHint: 'Organisez les sièges ici pour fiabiliser les rôles d’adjacence.',
+      balanceTitle: 'Retour sur l’équilibre',
+      balanceGood: 'Prêt',
+      balanceNeedsAttention: 'À surveiller',
+      balanceGoodBody: 'Cette composition garde des loups, de l’information et un chaos encore gérable à la table.',
+      defaultSessionName: (count: number) => `Table de ${count} joueurs`,
+      metrics: {
+        players: 'Joueurs',
+        wolfPressure: 'Pression des loups',
+        infoRoles: 'Rôles d’info',
+        chaos: 'Chaos',
+      },
+      balanceWarnings: {
+        needPressure: 'Ajoutez plus de pression côté loups sinon le village risque de dérouler trop facilement.',
+        needInformation: 'Ajoutez au moins un rôle d’information ou de protection pour donner une direction au village.',
+        tooChaotic: 'Cette composition empile beaucoup de rôles swingy. Attendez-vous à une partie très variable.',
+      },
       numberOfPlayers: 'Nombre de joueurs',
       assignRoles: 'Attribuer les rôles',
       viewRoleDescriptions: 'Rôles',
@@ -634,16 +798,34 @@ const translations: Record<Language, Strings> = {
         `${phase === 'night' ? '🌙 Nuit' : '☀️ Jour'} — Manche ${round}`,
       alive: (count: number) => `🫀 ${count} vivants`,
       wolves: (count: number) => `🐺 ${count} loups`,
+      unresolved: (count: number) => `📌 ${count} en attente`,
       resetConfirm: 'Réinitialiser et revenir à la préparation ?',
       reset: '🏠 Préparation',
+      undo: '↩ Annuler',
+      privacyOn: '🙈 Privé',
+      privacyOff: '👁 Révéler',
+      privacyTitle: 'Le mode confidentialité est actif',
+      privacyBody: 'Utilisez-le pour passer le téléphone ou masquer les informations MJ en direct.',
+      quickPanel: 'Panneau MJ',
       tabs: {
-        game: '🎮 Partie',
-        roles: '📚 Rôles',
+        game: '🎮 Conduite',
+        roles: '📚 Référence',
         log: '📜 Journal',
       },
       log: {
         title: '📜 Journal de partie',
         empty: 'Aucun événement pour le moment.',
+      },
+      recapTitle: 'Récapitulatif',
+      exportRecap: 'Exporter le récap',
+      endReason: 'Pourquoi la partie se termine',
+      endReasons: {
+        village: 'Le village gagne car aucun loup de meute ni Loup-Garou Blanc n’est encore en vie.',
+        werewolves: (wolves: number, village: number) =>
+          `Les loups atteignent la parité avec ${wolves} joueurs côté loups contre ${village} côté village.`,
+        piedPiper: 'Le Joueur de Flûte gagne car tous les autres joueurs vivants sont envoûtés.',
+        whiteWerewolf: 'Le Loup-Garou Blanc gagne car il est le seul survivant.',
+        angel: 'L’Ange gagne car il a été la première exécution du Jour 1.',
       },
       wins: {
         village: { title: 'Victoire du village !', body: 'Tous les loups-garous sont éliminés.' },
@@ -746,10 +928,18 @@ const translations: Record<Language, Strings> = {
     day: {
       title: (round: number) => `Phase de jour — Manche ${round}`,
       subtitle: 'Tous les joueurs ouvrent les yeux.',
+      metrics: {
+        alive: 'Vivants',
+        pressure: 'Pression des loups',
+        unresolved: 'En attente',
+        timer: 'Timer',
+      },
       dmView: { show: '👁 Vue MJ', hide: '🙈 Masquer les rôles' },
       bearSignal: (growls: boolean) =>
         growls ? '🐻 Signal de l’ours : 🔊 GROGNE (loup voisin !)' : '🐻 Signal de l’ours : 🤫 Silencieux',
       dmReminders: '📋 Rappels MJ',
+      resolutionTitle: 'File de résolution de l’aube',
+      resolutionHint: 'Résolvez les morts, chaînes et rappels publics dans l’ordre avant de clore le vote.',
       piedPiperBar: (count: number, total: number) =>
         `🎶 Envoûtés par le Joueur de Flûte : ${count} / ${total} joueurs`,
       piedPiperWins: '⭐ VICTOIRE DU JOUEUR DE FLÛTE !',
@@ -759,6 +949,16 @@ const translations: Record<Language, Strings> = {
       witchPotionsStatus: (healUsed: boolean, poisonUsed: boolean) =>
         `🧙‍♀️ Potions de la Sorcière — Vie : ${healUsed ? 'UTILISÉE' : 'disponible'}, Mort : ${poisonUsed ? 'UTILISÉE' : 'disponible'}.`,
       witchPotionsSpent: '🧙‍♀️ La Sorcière n’a plus de potions (ne se réveillera plus).',
+      voteAssistTitle: 'Assistant de vote',
+      voteAssistHint: 'Suivez le vote de table ici, tout en gardant la main pour corriger manuellement.',
+      voteAssistEnable: 'Démarrer le suivi',
+      voteAssistDisable: 'Masquer le suivi',
+      clearVotes: 'Effacer les votes',
+      totalVotes: (count: number) => `Total contre : ${count}`,
+      mayorPlusTwo: 'Maire +2',
+      noVote: 'Sans vote',
+      allowVote: 'Autoriser',
+      tieDetected: (names: string) => `Égalité détectée entre : ${names}`,
       playersTitle: (alive: number) => `👥 Joueurs (${alive} vivants)`,
       tieResolutionTitle: '⚖️ Gestion de l’égalité',
       tieResolutionHint: 'Utilisez ceci uniquement si le vote réel autour de la table finit à égalité.',
@@ -788,8 +988,11 @@ const translations: Record<Language, Strings> = {
       lover: '💘 Amoureux',
       makeMayor: '🎖️ Maire',
       eliminate: '☠️ Élim.',
+      revealRole: '👁 Révéler',
+      hideRole: '🙈 Masquer',
       mayorTitle: 'Nommer Maire',
       eliminateTitle: 'Éliminer',
+      revealTitle: 'Afficher ou masquer le rôle',
     },
     tieBreaker: {
       title: '⚖️ Bris d’égalité',

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -1,11 +1,18 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type {
-  Player,
   GameState,
+  Language,
   NightStep,
   NightStepState,
-  Language,
+  Player,
+  PlayerStatus,
+  ResolutionItem,
+  SavedSession,
+  SessionSnapshot,
+  SessionState,
+  UIMode,
+  VoteState,
 } from '../types/game.types';
 import { getNightOrder, WOLF_ROLE_IDS } from '../data/roles';
 import { getStrings } from '../i18n';
@@ -15,10 +22,19 @@ interface SetupState {
   roleIds: string[];
   discussionTime: number;
   optionalRules: Record<string, boolean>;
+  savedSessions: SavedSession[];
+}
+
+interface SetupConfig {
+  playerNames: string[];
+  roleIds: string[];
+  discussionTime: number;
+  optionalRules: Record<string, boolean>;
+  seatOrder?: string[];
 }
 
 interface StoreActions {
-  setSetup: (s: SetupState) => void;
+  setSetup: (s: SetupConfig) => void;
   startGame: () => void;
   resetGame: () => void;
   completeNightStep: () => void;
@@ -45,6 +61,20 @@ interface StoreActions {
   addLog: (message: string) => void;
   setLanguage: (lang: Language) => void;
   setProtectorTarget: (targetId: string | null) => void;
+  setUiMode: (mode: UIMode) => void;
+  togglePrivacyMode: () => void;
+  moveSeat: (playerId: string, direction: 'up' | 'down') => void;
+  setPlayerStatusFlag: <K extends keyof PlayerStatus>(playerId: string, flag: K, value?: boolean) => void;
+  toggleRoleReveal: (playerId: string) => void;
+  undoLastAction: () => void;
+  saveNamedSession: (name: string) => void;
+  loadNamedSession: (sessionId: string) => void;
+  deleteNamedSession: (sessionId: string) => void;
+  setVoteAssistActive: (active: boolean) => void;
+  adjustVote: (playerId: string, delta: number) => void;
+  toggleNoVote: (playerId: string) => void;
+  resetVoteAssist: () => void;
+  clearResolutionQueue: () => void;
 }
 
 export type GameStore = SetupState & GameState & StoreActions;
@@ -54,6 +84,7 @@ const defaultSetup: SetupState = {
   roleIds: [],
   discussionTime: 180,
   optionalRules: {},
+  savedSessions: [],
 };
 
 const defaultGame: GameState = {
@@ -85,7 +116,31 @@ const defaultGame: GameState = {
   language: 'en',
   protectedPlayerId: null,
   lastProtectedPlayerId: null,
+  seatOrder: [],
+  playerStatuses: {},
+  resolutionQueue: [],
+  sessionSnapshots: [],
+  uiMode: 'prepare',
+  privacyMode: false,
+  voteAssist: null,
 };
+
+function createDefaultPlayerStatus(): PlayerStatus {
+  return {
+    protected: false,
+    cursed: false,
+    silenced: false,
+    noVote: false,
+    cannotBeProtected: false,
+    enchanted: false,
+    infected: false,
+    lovers: false,
+    mayor: false,
+    roleLocked: false,
+    revealed: false,
+    transformed: false,
+  };
+}
 
 function buildNightSteps(
   roleIds: string[],
@@ -99,16 +154,267 @@ function buildNightSteps(
   );
 
   return getNightOrder(roleIds, round, foxPowerActive)
-    .filter((r) => r.id !== 'witch' || witchPotionsAvailable)
-    .map((r, i) => ({
-      roleId: r.id,
-      stepIndex: i,
+    .filter((role) => role.id !== 'witch' || witchPotionsAvailable)
+    .map((role, index) => ({
+      roleId: role.id,
+      stepIndex: index,
       completed: false,
     }));
 }
 
 function clonePlayers(players: Player[]) {
-  return players.map((p) => ({ ...p }));
+  return players.map((player) => ({ ...player, usedAbilities: [...player.usedAbilities] }));
+}
+
+function cloneStatuses(statuses: Record<string, PlayerStatus>) {
+  return Object.fromEntries(
+    Object.entries(statuses).map(([id, status]) => [id, { ...status }])
+  ) as Record<string, PlayerStatus>;
+}
+
+function cloneVoteAssist(voteAssist: VoteState | null) {
+  if (!voteAssist) return null;
+  return {
+    active: voteAssist.active,
+    votes: { ...voteAssist.votes },
+    noVoteIds: [...voteAssist.noVoteIds],
+  };
+}
+
+function normalizeSeatOrder(players: Pick<Player, 'id'>[], seatOrder: string[]) {
+  const validIds = new Set(players.map((player) => player.id));
+  const ordered = seatOrder.filter((id) => validIds.has(id));
+  const missing = players.map((player) => player.id).filter((id) => !ordered.includes(id));
+  return [...ordered, ...missing];
+}
+
+function getPlayersInSeatOrder(players: Player[], seatOrder: string[]) {
+  const order = normalizeSeatOrder(players, seatOrder);
+  return order
+    .map((id) => players.find((player) => player.id === id))
+    .filter((player): player is Player => Boolean(player));
+}
+
+function reorderArrayItem<T>(items: T[], fromIndex: number, toIndex: number) {
+  const next = [...items];
+  const [moved] = next.splice(fromIndex, 1);
+  next.splice(toIndex, 0, moved);
+  return next;
+}
+
+function buildVoteAssist(players: Player[], current?: VoteState | null): VoteState {
+  return {
+    active: current?.active ?? true,
+    votes: Object.fromEntries(players.map((player) => [player.id, current?.votes[player.id] ?? 0])),
+    noVoteIds: [...(current?.noVoteIds ?? [])].filter((id) => players.some((player) => player.id === id)),
+  };
+}
+
+function derivePlayerStatuses(state: Pick<
+  GameStore,
+  | 'players'
+  | 'playerStatuses'
+  | 'protectedPlayerId'
+  | 'ravenCursedId'
+  | 'enchantedPlayerIds'
+  | 'infectedPlayerIds'
+  | 'loversIds'
+  | 'mayorId'
+  | 'wildChildTransformed'
+  | 'wolfDogChoice'
+  | 'voteAssist'
+> & Partial<GameStore>) {
+  return Object.fromEntries(
+    state.players.map((player) => {
+      const current = state.playerStatuses[player.id] ?? createDefaultPlayerStatus();
+      const transformed =
+        (player.roleId === 'wild_child' && state.wildChildTransformed) ||
+        (player.roleId === 'wolf_dog' && state.wolfDogChoice === 'werewolf');
+
+      return [
+        player.id,
+        {
+          ...current,
+          protected: state.protectedPlayerId === player.id,
+          cursed: state.ravenCursedId === player.id,
+          enchanted: state.enchantedPlayerIds.includes(player.id),
+          infected: state.infectedPlayerIds.includes(player.id),
+          lovers: state.loversIds?.includes(player.id) ?? false,
+          mayor: state.mayorId === player.id,
+          noVote: current.noVote || (state.voteAssist?.noVoteIds.includes(player.id) ?? false),
+          transformed,
+        },
+      ];
+    })
+  ) as Record<string, PlayerStatus>;
+}
+
+function cloneSessionState(state: SessionState): SessionState {
+  return {
+    phase: state.phase,
+    round: state.round,
+    players: clonePlayers(state.players),
+    nightSteps: state.nightSteps.map((step) => ({ ...step })),
+    currentNightStepIndex: state.currentNightStepIndex,
+    eliminatedThisNight: [...state.eliminatedThisNight],
+    discussionTimeSeconds: state.discussionTimeSeconds,
+    timerRunning: state.timerRunning,
+    timerRemaining: state.timerRemaining,
+    loversIds: state.loversIds ? [...state.loversIds] as [string, string] : null,
+    mayorId: state.mayorId,
+    log: [...state.log],
+    usedGameAbilities: [...state.usedGameAbilities],
+    optionalRules: { ...state.optionalRules },
+    foxPowerActive: state.foxPowerActive,
+    wildChildModelId: state.wildChildModelId,
+    wildChildTransformed: state.wildChildTransformed,
+    wolfDogChoice: state.wolfDogChoice,
+    enchantedPlayerIds: [...state.enchantedPlayerIds],
+    infectedPlayerIds: [...state.infectedPlayerIds],
+    angelWon: state.angelWon,
+    wolfVictimId: state.wolfVictimId,
+    ravenCursedId: state.ravenCursedId,
+    language: state.language,
+    nightStepStates: state.nightStepStates.map((snapshot) => ({
+      ...snapshot,
+      eliminatedThisNight: [...snapshot.eliminatedThisNight],
+      usedGameAbilities: [...snapshot.usedGameAbilities],
+      enchantedPlayerIds: [...snapshot.enchantedPlayerIds],
+      infectedPlayerIds: [...snapshot.infectedPlayerIds],
+      loversIds: snapshot.loversIds ? [...snapshot.loversIds] as [string, string] : null,
+      players: clonePlayers(snapshot.players),
+      protectorHistory: snapshot.protectorHistory.map((entry) => ({ ...entry })),
+    })),
+    protectorHistory: state.protectorHistory.map((entry) => ({ ...entry })),
+    protectedPlayerId: state.protectedPlayerId,
+    lastProtectedPlayerId: state.lastProtectedPlayerId,
+    seatOrder: [...state.seatOrder],
+    playerStatuses: cloneStatuses(state.playerStatuses),
+    resolutionQueue: state.resolutionQueue.map((item) => ({ ...item, playerIds: [...item.playerIds] })),
+    uiMode: state.uiMode,
+    privacyMode: state.privacyMode,
+    voteAssist: cloneVoteAssist(state.voteAssist),
+  };
+}
+
+function captureSessionState(state: GameStore): SessionState {
+  return cloneSessionState({
+    phase: state.phase,
+    round: state.round,
+    players: state.players,
+    nightSteps: state.nightSteps,
+    currentNightStepIndex: state.currentNightStepIndex,
+    eliminatedThisNight: state.eliminatedThisNight,
+    discussionTimeSeconds: state.discussionTimeSeconds,
+    timerRunning: state.timerRunning,
+    timerRemaining: state.timerRemaining,
+    loversIds: state.loversIds,
+    mayorId: state.mayorId,
+    log: state.log,
+    usedGameAbilities: state.usedGameAbilities,
+    optionalRules: state.optionalRules,
+    foxPowerActive: state.foxPowerActive,
+    wildChildModelId: state.wildChildModelId,
+    wildChildTransformed: state.wildChildTransformed,
+    wolfDogChoice: state.wolfDogChoice,
+    enchantedPlayerIds: state.enchantedPlayerIds,
+    infectedPlayerIds: state.infectedPlayerIds,
+    angelWon: state.angelWon,
+    wolfVictimId: state.wolfVictimId,
+    ravenCursedId: state.ravenCursedId,
+    language: state.language,
+    nightStepStates: state.nightStepStates,
+    protectorHistory: state.protectorHistory,
+    protectedPlayerId: state.protectedPlayerId,
+    lastProtectedPlayerId: state.lastProtectedPlayerId,
+    seatOrder: state.seatOrder,
+    playerStatuses: state.playerStatuses,
+    resolutionQueue: state.resolutionQueue,
+    uiMode: state.uiMode,
+    privacyMode: state.privacyMode,
+    voteAssist: state.voteAssist,
+  });
+}
+
+function createSnapshot(state: GameStore, reason: string): SessionSnapshot {
+  return {
+    id: `snapshot-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    reason,
+    createdAt: Date.now(),
+    state: captureSessionState(state),
+  };
+}
+
+function buildResolutionQueue(
+  state: GameStore,
+  strings: ReturnType<typeof getStrings>,
+  finalEliminated: string[],
+  extraLogParts: string[],
+  protectedSaved: boolean
+): ResolutionItem[] {
+  const queue: ResolutionItem[] = [];
+
+  if (protectedSaved && state.protectedPlayerId) {
+    const protectedName = state.players.find((player) => player.id === state.protectedPlayerId)?.name;
+    if (protectedName) {
+      queue.push({
+        id: `resolution-save-${state.round}`,
+        round: state.round,
+        phase: 'day',
+        type: 'save',
+        title: 'Protection held',
+        detail: `${protectedName} survived because the Protector covered them.`,
+        playerIds: [state.protectedPlayerId],
+        public: false,
+      });
+    }
+  }
+
+  finalEliminated.forEach((playerId, index) => {
+    const player = state.players.find((candidate) => candidate.id === playerId);
+    if (!player) return;
+    queue.push({
+      id: `resolution-death-${state.round}-${index}`,
+      round: state.round,
+      phase: 'day',
+      type: 'death',
+      title: `${player.name} dies`,
+      detail: `${player.name} should be removed at dawn.`,
+      playerIds: [playerId],
+      public: true,
+    });
+  });
+
+  extraLogParts.forEach((message, index) => {
+    queue.push({
+      id: `resolution-extra-${state.round}-${index}`,
+      round: state.round,
+      phase: 'day',
+      type: 'chain',
+      title: strings.game.log.title,
+      detail: message,
+      playerIds: [],
+      public: false,
+    });
+  });
+
+  if (state.ravenCursedId) {
+    const cursedName = state.players.find((player) => player.id === state.ravenCursedId)?.name;
+    if (cursedName) {
+      queue.push({
+        id: `resolution-raven-${state.round}`,
+        round: state.round,
+        phase: 'day',
+        type: 'status',
+        title: 'Raven curse',
+        detail: `${cursedName} starts the day with +2 votes against them.`,
+        playerIds: [state.ravenCursedId],
+        public: false,
+      });
+    }
+  }
+
+  return queue;
 }
 
 function captureNightState(state: GameStore): NightStepState {
@@ -124,7 +430,7 @@ function captureNightState(state: GameStore): NightStepState {
     ravenCursedId: state.ravenCursedId,
     wildChildModelId: state.wildChildModelId,
     wolfDogChoice: state.wolfDogChoice,
-    protectorHistory: state.protectorHistory.map((p) => ({ ...p })),
+    protectorHistory: state.protectorHistory.map((entry) => ({ ...entry })),
     protectedPlayerId: state.protectedPlayerId,
     lastProtectedPlayerId: state.lastProtectedPlayerId,
   };
@@ -134,23 +440,22 @@ export function resolveNightEliminations(
   players: Player[],
   eliminatedThisNight: string[],
   infectedPlayerIds: string[],
-  loversIds: [string, string] | null
+  loversIds: [string, string] | null,
+  seatOrder: string[] = []
 ) {
   const finalEliminated = [...eliminatedThisNight];
   let knightLog = '';
   let loversLog = '';
+  const orderedPlayers = getPlayersInSeatOrder(players, seatOrder);
 
-  const knightPlayer = players.find((p) => p.isAlive && p.roleId === 'knight');
+  const knightPlayer = players.find((player) => player.isAlive && player.roleId === 'knight');
   if (knightPlayer && finalEliminated.includes(knightPlayer.id)) {
-    const total = players.length;
-    const knightIdx = players.findIndex((p) => p.id === knightPlayer.id);
+    const total = orderedPlayers.length;
+    const knightIndex = orderedPlayers.findIndex((player) => player.id === knightPlayer.id);
     for (let offset = 1; offset < total; offset++) {
-      const candidate = players[(knightIdx - offset + total) % total];
+      const candidate = orderedPlayers[(knightIndex - offset + total) % total];
       if (!candidate.isAlive) continue;
-      if (
-        WOLF_ROLE_IDS.includes(candidate.roleId) ||
-        infectedPlayerIds.includes(candidate.id)
-      ) {
+      if (WOLF_ROLE_IDS.includes(candidate.roleId) || infectedPlayerIds.includes(candidate.id)) {
         if (!finalEliminated.includes(candidate.id)) {
           finalEliminated.push(candidate.id);
           knightLog = `⚔️ Knight's rusty sword: ${candidate.name} dies of tetanus!`;
@@ -168,11 +473,11 @@ export function resolveNightEliminations(
     if (loverAEliminated !== loverBEliminated) {
       const chainedId = loverAEliminated ? loverBId : loverAId;
       const fallenId = loverAEliminated ? loverAId : loverBId;
-      const chainedPlayer = players.find((p) => p.id === chainedId);
+      const chainedPlayer = players.find((player) => player.id === chainedId);
 
       if (chainedPlayer?.isAlive && !finalEliminated.includes(chainedId)) {
         finalEliminated.push(chainedId);
-        const fallenName = players.find((p) => p.id === fallenId)?.name ?? 'Unknown';
+        const fallenName = players.find((player) => player.id === fallenId)?.name ?? 'Unknown';
         loversLog = `💘 Lovers: ${chainedPlayer.name} dies with ${fallenName}.`;
       }
     }
@@ -187,15 +492,28 @@ export const useGameStore = create<GameStore>()(
       ...defaultSetup,
       ...defaultGame,
 
-      setSetup: (s) => set({ ...s }),
+      setSetup: (setup) =>
+        set((state) => ({
+          playerNames: [...setup.playerNames],
+          roleIds: [...setup.roleIds],
+          discussionTime: setup.discussionTime,
+          optionalRules: { ...setup.optionalRules },
+          seatOrder:
+            setup.seatOrder && setup.seatOrder.length === setup.playerNames.length
+              ? [...setup.seatOrder]
+              : normalizeSeatOrder(
+                  setup.playerNames.map((_, index) => ({ id: `p${index}` })),
+                  state.seatOrder
+                ),
+        })),
 
       startGame: () => {
-        const { playerNames, roleIds, discussionTime, optionalRules, language } = get();
+        const { playerNames, roleIds, discussionTime, optionalRules, language, seatOrder } = get();
         const strings = getStrings(language);
-        const players: Player[] = playerNames.map((name, i) => ({
-          id: `p${i}`,
+        const players: Player[] = playerNames.map((name, index) => ({
+          id: `p${index}`,
           name,
-          roleId: roleIds[i] ?? 'villager',
+          roleId: roleIds[index] ?? 'villager',
           isAlive: true,
           isMayor: false,
           isLover: false,
@@ -203,13 +521,15 @@ export const useGameStore = create<GameStore>()(
           usedAbilities: [],
         }));
         const round = 1;
+        const normalizedSeatOrder = normalizeSeatOrder(players, seatOrder);
         const nightSteps = buildNightSteps(
-          [...new Set(players.map((p) => p.roleId))],
+          [...new Set(players.map((player) => player.roleId))],
           round,
           true,
           []
         );
-        const nextState: Partial<GameStore> = {
+        const snapshotBase = {
+          ...get(),
           phase: 'night',
           round,
           players,
@@ -222,7 +542,7 @@ export const useGameStore = create<GameStore>()(
           mayorId: null,
           log: [strings.logs.gameStarted(players.length)],
           usedGameAbilities: [],
-          optionalRules,
+          optionalRules: { ...optionalRules },
           foxPowerActive: true,
           protectorHistory: [],
           wildChildModelId: null,
@@ -233,133 +553,164 @@ export const useGameStore = create<GameStore>()(
           angelWon: false,
           wolfVictimId: null,
           ravenCursedId: null,
-          language: language ?? 'en',
           protectedPlayerId: null,
           lastProtectedPlayerId: null,
-        };
-        const snapshotBase = { ...get(), ...nextState, nightStepStates: [] } as GameStore;
+          seatOrder: normalizedSeatOrder,
+          playerStatuses: Object.fromEntries(players.map((player) => [player.id, createDefaultPlayerStatus()])),
+          resolutionQueue: [],
+          sessionSnapshots: [],
+          uiMode: 'run' as UIMode,
+          privacyMode: false,
+          voteAssist: null,
+          nightStepStates: [],
+        } as GameStore;
         const nightStepStates = [captureNightState(snapshotBase)];
-        set({ ...nextState, nightStepStates });
+        const playerStatuses = derivePlayerStatuses({ ...snapshotBase, nightStepStates });
+        const nextState = { ...snapshotBase, nightStepStates, playerStatuses };
+        set({
+          ...nextState,
+          sessionSnapshots: [createSnapshot(nextState, 'Game start')],
+        });
       },
 
-      resetGame: () => set((s) => ({ ...defaultSetup, ...defaultGame, language: s.language })),
+      resetGame: () =>
+        set((state) => ({
+          ...defaultSetup,
+          ...defaultGame,
+          language: state.language,
+          savedSessions: state.savedSessions,
+        })),
 
       completeNightStep: () =>
         set((state) => {
-          const updated = state.nightSteps.map((s, i) =>
-            i === state.currentNightStepIndex ? { ...s, completed: true } : s
+          const nightSteps = state.nightSteps.map((step, index) =>
+            index === state.currentNightStepIndex ? { ...step, completed: true } : step
           );
-          const nextIndex = state.currentNightStepIndex + 1;
-          const history = [...(state.nightStepStates ?? [])];
-          history[nextIndex] = captureNightState(state);
-          return {
-            nightSteps: updated,
-            currentNightStepIndex: nextIndex,
-            nightStepStates: history,
-          };
+          const currentNightStepIndex = state.currentNightStepIndex + 1;
+          const nightStepStates = [...state.nightStepStates];
+          nightStepStates[currentNightStepIndex] = captureNightState(state);
+          return { nightSteps, currentNightStepIndex, nightStepStates };
         }),
 
       goToNightStep: (index) =>
         set((state) => {
           const target = Math.max(0, Math.min(index, state.nightSteps.length - 1));
-          const history = state.nightStepStates ?? [];
-          const snapshot = history[target];
+          const snapshot = state.nightStepStates[target];
           if (!snapshot) return {};
-          const nightSteps = state.nightSteps.map((step, i) => ({
+          const players = clonePlayers(snapshot.players);
+          const nightSteps = state.nightSteps.map((step, stepIndex) => ({
             ...step,
-            completed: i < target,
+            completed: stepIndex < target,
           }));
+          const voteAssist = state.voteAssist ? buildVoteAssist(players, state.voteAssist) : null;
+          const playerStatuses = derivePlayerStatuses({
+            ...state,
+            players,
+            enchantedPlayerIds: [...snapshot.enchantedPlayerIds],
+            infectedPlayerIds: [...snapshot.infectedPlayerIds],
+            loversIds: snapshot.loversIds ? [...snapshot.loversIds] as [string, string] : null,
+            ravenCursedId: snapshot.ravenCursedId,
+            protectedPlayerId: snapshot.protectedPlayerId,
+            lastProtectedPlayerId: snapshot.lastProtectedPlayerId,
+            wolfDogChoice: snapshot.wolfDogChoice,
+            voteAssist,
+          });
           return {
             eliminatedThisNight: [...snapshot.eliminatedThisNight],
             usedGameAbilities: [...snapshot.usedGameAbilities],
             enchantedPlayerIds: [...snapshot.enchantedPlayerIds],
             infectedPlayerIds: [...snapshot.infectedPlayerIds],
             loversIds: snapshot.loversIds ? [...snapshot.loversIds] as [string, string] : null,
-            players: clonePlayers(snapshot.players),
+            players,
             foxPowerActive: snapshot.foxPowerActive,
             wolfVictimId: snapshot.wolfVictimId,
             ravenCursedId: snapshot.ravenCursedId,
             wildChildModelId: snapshot.wildChildModelId,
             wolfDogChoice: snapshot.wolfDogChoice,
-            protectorHistory: snapshot.protectorHistory.map((p) => ({ ...p })),
+            protectorHistory: snapshot.protectorHistory.map((entry) => ({ ...entry })),
             protectedPlayerId: snapshot.protectedPlayerId,
             lastProtectedPlayerId: snapshot.lastProtectedPlayerId,
             nightSteps,
             currentNightStepIndex: target,
-            nightStepStates: history.slice(0, target + 1),
+            nightStepStates: state.nightStepStates.slice(0, target + 1),
+            voteAssist,
+            playerStatuses,
           };
         }),
 
       setEliminatedThisNight: (ids) => set({ eliminatedThisNight: ids }),
-
-      useGameAbility: (key) =>
-        set((s) => ({ usedGameAbilities: [...s.usedGameAbilities, key] })),
-
+      useGameAbility: (key) => set((state) => ({ usedGameAbilities: [...state.usedGameAbilities, key] })),
       setWildChildModel: (id) => set({ wildChildModelId: id }),
-      setWolfDogChoice: (choice) => set({ wolfDogChoice: choice }),
-      addEnchanted: (ids) =>
-        set((s) => ({ enchantedPlayerIds: [...new Set([...s.enchantedPlayerIds, ...ids])] })),
-      infectPlayer: (id) =>
-        set((s) => ({
-          eliminatedThisNight: s.eliminatedThisNight.filter((eid) => eid !== id),
-          infectedPlayerIds: [...new Set([...s.infectedPlayerIds, id])],
-          usedGameAbilities: [...s.usedGameAbilities, 'infect_pere'],
+      setWolfDogChoice: (choice) =>
+        set((state) => ({
+          wolfDogChoice: choice,
+          playerStatuses: derivePlayerStatuses({ ...state, wolfDogChoice: choice }),
         })),
+      addEnchanted: (ids) =>
+        set((state) => {
+          const enchantedPlayerIds = [...new Set([...state.enchantedPlayerIds, ...ids])];
+          return {
+            enchantedPlayerIds,
+            playerStatuses: derivePlayerStatuses({ ...state, enchantedPlayerIds }),
+          };
+        }),
+      infectPlayer: (id) =>
+        set((state) => {
+          const infectedPlayerIds = [...new Set([...state.infectedPlayerIds, id])];
+          return {
+            eliminatedThisNight: state.eliminatedThisNight.filter((playerId) => playerId !== id),
+            infectedPlayerIds,
+            usedGameAbilities: [...state.usedGameAbilities, 'infect_pere'],
+            playerStatuses: derivePlayerStatuses({ ...state, infectedPlayerIds }),
+          };
+        }),
       setAngelWon: (val) => set({ angelWon: val }),
       setFoxPowerActive: (active) => set({ foxPowerActive: active }),
       setWolfVictimId: (id) => set({ wolfVictimId: id }),
-      setRavenCursed: (id) => set({ ravenCursedId: id }),
+      setRavenCursed: (id) =>
+        set((state) => ({
+          ravenCursedId: id,
+          playerStatuses: derivePlayerStatuses({ ...state, ravenCursedId: id }),
+        })),
       setProtectorTarget: (targetId) =>
-        set((s) => {
-          const withoutCurrentRound = s.protectorHistory.filter((p) => p.round !== s.round);
+        set((state) => {
+          const protectorHistory = [
+            ...state.protectorHistory.filter((entry) => entry.round !== state.round),
+            { round: state.round, targetId },
+          ];
           return {
-            protectorHistory: [...withoutCurrentRound, { round: s.round, targetId }],
+            protectorHistory,
             protectedPlayerId: targetId,
+            playerStatuses: derivePlayerStatuses({ ...state, protectorHistory, protectedPlayerId: targetId }),
           };
         }),
 
       applyNightResults: () => {
-        const {
-          players,
-          eliminatedThisNight,
-          round,
-          discussionTimeSeconds,
-          optionalRules,
-          infectedPlayerIds,
-          wildChildModelId,
-          wildChildTransformed,
-          log,
-          foxPowerActive,
-          usedGameAbilities,
-          protectorHistory,
-          loversIds,
-          protectedPlayerId,
-        } = get();
-        const strings = getStrings(get().language);
+        const state = get();
+        const strings = getStrings(state.language);
         const extraLogParts: string[] = [];
         const { finalEliminated, knightLog, loversLog } = resolveNightEliminations(
-          players,
-          eliminatedThisNight,
-          infectedPlayerIds,
-          loversIds
+          state.players,
+          state.eliminatedThisNight,
+          state.infectedPlayerIds,
+          state.loversIds,
+          state.seatOrder
         );
 
         if (knightLog) extraLogParts.push(knightLog);
         if (loversLog) extraLogParts.push(loversLog);
 
-        const witchHealUsed = usedGameAbilities.includes('witch_heal');
-        const witchPoisonUsed = usedGameAbilities.includes('witch_poison');
+        const witchHealUsed = state.usedGameAbilities.includes('witch_heal');
+        const witchPoisonUsed = state.usedGameAbilities.includes('witch_poison');
         if (witchHealUsed || witchPoisonUsed) {
           extraLogParts.push(strings.logs.witchPotionsStatus(witchHealUsed, witchPoisonUsed));
-          if (witchHealUsed && witchPoisonUsed) {
-            extraLogParts.push(strings.logs.witchPotionsSpent);
-          }
+          if (witchHealUsed && witchPoisonUsed) extraLogParts.push(strings.logs.witchPotionsSpent);
         }
 
-        const protectionEntry = protectorHistory.find((p) => p.round === round);
+        const protectionEntry = state.protectorHistory.find((entry) => entry.round === state.round);
         if (protectionEntry) {
           const targetName = protectionEntry.targetId
-            ? players.find((p) => p.id === protectionEntry.targetId)?.name ?? strings.night.protectorUnknown
+            ? state.players.find((player) => player.id === protectionEntry.targetId)?.name ?? strings.night.protectorUnknown
             : '';
           extraLogParts.push(
             protectionEntry.targetId
@@ -368,145 +719,359 @@ export const useGameStore = create<GameStore>()(
           );
         }
 
-        const updated = players.map((p) =>
-          finalEliminated.includes(p.id) ? { ...p, isAlive: false } : p
+        const players = state.players.map((player) =>
+          finalEliminated.includes(player.id) ? { ...player, isAlive: false } : player
         );
-
-        const newWildChildTransformed =
-          wildChildTransformed ||
-          (wildChildModelId !== null && finalEliminated.includes(wildChildModelId));
-
-        const roleIds = [...new Set(updated.filter((p) => p.isAlive).map((p) => p.roleId))];
-        const newRound = round + 1;
-        const nightSteps = buildNightSteps(roleIds, newRound, foxPowerActive, usedGameAbilities);
-
+        const wildChildTransformed =
+          state.wildChildTransformed ||
+          (state.wildChildModelId !== null && finalEliminated.includes(state.wildChildModelId));
+        const roleIds = [...new Set(players.filter((player) => player.isAlive).map((player) => player.roleId))];
+        const newRound = state.round + 1;
+        const nightSteps = buildNightSteps(roleIds, newRound, state.foxPowerActive, state.usedGameAbilities);
         const eliminatedNames = finalEliminated
-          .map((id) => updated.find((p) => p.id === id)?.name)
+          .map((playerId) => players.find((player) => player.id === playerId)?.name)
           .filter(Boolean)
           .join(', ');
-
         const nightMsg = strings.logs.nightSummary(
-          round,
+          state.round,
           eliminatedNames || null,
           extraLogParts.length > 0 ? ` ${extraLogParts.join(' ')}` : ''
         );
-
-        set({
-          players: updated,
-          phase: 'day',
+        const protectedSaved =
+          !!state.protectedPlayerId &&
+          state.protectedPlayerId === state.wolfVictimId &&
+          !finalEliminated.includes(state.protectedPlayerId);
+        const voteAssist = null;
+        const resolutionQueue = buildResolutionQueue(state, strings, finalEliminated, extraLogParts, protectedSaved);
+        const base = {
+          ...state,
+          players,
+          phase: 'day' as const,
           eliminatedThisNight: [],
           nightSteps,
           currentNightStepIndex: 0,
           nightStepStates: [],
-          timerRemaining: discussionTimeSeconds,
-          log: [...log, nightMsg],
-          optionalRules,
-          wildChildTransformed: newWildChildTransformed,
+          timerRemaining: state.discussionTimeSeconds,
+          log: [...state.log, nightMsg],
+          wildChildTransformed,
           wolfVictimId: null,
           protectedPlayerId: null,
-          lastProtectedPlayerId: protectedPlayerId,
+          lastProtectedPlayerId: state.protectedPlayerId,
+          resolutionQueue,
+          voteAssist,
+          uiMode: 'run' as UIMode,
+        };
+        const playerStatuses = derivePlayerStatuses(base);
+        set({
+          ...base,
+          playerStatuses,
+          sessionSnapshots: [...state.sessionSnapshots, createSnapshot({ ...base, playerStatuses } as GameStore, `Reveal day ${state.round}`)],
         });
       },
 
       togglePhase: () => {
-        const {
-          phase,
-          round,
-          players,
-          discussionTimeSeconds,
-          optionalRules,
-          foxPowerActive,
-          usedGameAbilities,
-        } = get();
-        if (phase === 'day') {
-          const roleIds = [...new Set(players.filter((p) => p.isAlive).map((p) => p.roleId))];
-          const newRound = round + 1;
-          const nightSteps = buildNightSteps(roleIds, newRound, foxPowerActive, usedGameAbilities);
-          const nextState: Partial<GameStore> = {
-            phase: 'night',
-            round: newRound,
+        const state = get();
+        if (state.phase === 'day') {
+          const roleIds = [...new Set(state.players.filter((player) => player.isAlive).map((player) => player.roleId))];
+          const round = state.round + 1;
+          const nightSteps = buildNightSteps(roleIds, round, state.foxPowerActive, state.usedGameAbilities);
+          const base = {
+            ...state,
+            phase: 'night' as const,
+            round,
             nightSteps,
             currentNightStepIndex: 0,
             eliminatedThisNight: [],
-            optionalRules,
             ravenCursedId: null,
             protectedPlayerId: null,
+            resolutionQueue: [],
+            voteAssist: null,
+            nightStepStates: [],
+            uiMode: 'run' as UIMode,
           };
-          const snapshotBase = { ...get(), ...nextState, nightStepStates: [] } as GameStore;
-          const nightStepStates = [captureNightState(snapshotBase)];
-          set({ ...nextState, nightStepStates });
-        } else {
-          set({ phase: 'day', timerRemaining: discussionTimeSeconds, nightStepStates: [] });
+          const nightStepStates = [captureNightState(base as GameStore)];
+          const playerStatuses = derivePlayerStatuses({ ...base, nightStepStates });
+          set({
+            ...base,
+            nightStepStates,
+            playerStatuses,
+            sessionSnapshots: [...state.sessionSnapshots, createSnapshot({ ...base, nightStepStates, playerStatuses } as GameStore, `Start night ${round}`)],
+          });
+          return;
         }
+
+        const voteAssist = buildVoteAssist(state.players, state.voteAssist);
+        set({
+          phase: 'day',
+          timerRemaining: state.discussionTimeSeconds,
+          nightStepStates: [],
+          voteAssist,
+          playerStatuses: derivePlayerStatuses({ ...state, voteAssist }),
+        });
       },
 
       startTimer: () => set({ timerRunning: true }),
       stopTimer: () => set({ timerRunning: false }),
       tickTimer: () => {
         const { timerRemaining, timerRunning } = get();
-        if (timerRunning && timerRemaining > 0) {
-          set({ timerRemaining: timerRemaining - 1 });
-        } else if (timerRemaining <= 0) {
-          set({ timerRunning: false });
-        }
+        if (timerRunning && timerRemaining > 0) set({ timerRemaining: timerRemaining - 1 });
+        else if (timerRemaining <= 0) set({ timerRunning: false });
       },
-      resetTimer: () =>
-        set((s) => ({ timerRemaining: s.discussionTimeSeconds, timerRunning: false })),
+      resetTimer: () => set((state) => ({ timerRemaining: state.discussionTimeSeconds, timerRunning: false })),
 
       eliminatePlayer: (id) => {
-        const { players, loversIds, log, round, wildChildModelId, wildChildTransformed } = get();
-        const strings = getStrings(get().language);
-        const toElim = [id];
-        if (loversIds && loversIds.includes(id)) {
-          const other = loversIds.find((lid) => lid !== id);
-          if (other) toElim.push(other);
+        const state = get();
+        const strings = getStrings(state.language);
+        const toEliminate = [id];
+        if (state.loversIds && state.loversIds.includes(id)) {
+          const other = state.loversIds.find((loverId) => loverId !== id);
+          if (other) toEliminate.push(other);
         }
-        const updated = players.map((p) => toElim.includes(p.id) ? { ...p, isAlive: false } : p);
-        const newWildChildTransformed =
-          wildChildTransformed ||
-          (wildChildModelId !== null && toElim.includes(wildChildModelId));
-        const elimNames = toElim
-          .map((eid) => players.find((p) => p.id === eid)?.name)
+        const players = state.players.map((player) =>
+          toEliminate.includes(player.id) ? { ...player, isAlive: false } : player
+        );
+        const wildChildTransformed =
+          state.wildChildTransformed ||
+          (state.wildChildModelId !== null && toEliminate.includes(state.wildChildModelId));
+        const eliminatedNames = toEliminate
+          .map((playerId) => state.players.find((player) => player.id === playerId)?.name)
           .filter(Boolean)
           .join(' & ');
+        const resolutionQueue = [
+          {
+            id: `day-elim-${Date.now()}`,
+            round: state.round,
+            phase: 'day' as const,
+            type: 'death' as const,
+            title: `${eliminatedNames} eliminated`,
+            detail: strings.logs.dayElimination(state.round, eliminatedNames),
+            playerIds: [...toEliminate],
+            public: true,
+          },
+          ...state.resolutionQueue,
+        ];
+        const voteAssist = state.voteAssist ? buildVoteAssist(players, state.voteAssist) : null;
+        const base = {
+          ...state,
+          players,
+          wildChildTransformed,
+          log: [...state.log, strings.logs.dayElimination(state.round, eliminatedNames)],
+          resolutionQueue,
+          voteAssist,
+        };
+        const playerStatuses = derivePlayerStatuses(base);
         set({
-          players: updated,
-          wildChildTransformed: newWildChildTransformed,
-          log: [
-            ...log,
-            strings.logs.dayElimination(round, elimNames),
-          ],
+          ...base,
+          playerStatuses,
+          sessionSnapshots: [...state.sessionSnapshots, createSnapshot({ ...base, playerStatuses } as GameStore, `Eliminate ${eliminatedNames}`)],
         });
       },
 
       electMayor: (id) =>
-        set((s) => ({
-          mayorId: id,
-          players: s.players.map((p) => ({ ...p, isMayor: p.id === id })),
-        })),
+        set((state) => {
+          const players = state.players.map((player) => ({ ...player, isMayor: player.id === id }));
+          return {
+            mayorId: id,
+            players,
+            playerStatuses: derivePlayerStatuses({ ...state, players, mayorId: id }),
+          };
+        }),
 
       setLovers: (id1, id2) =>
-        set((s) => ({
-          loversIds: [id1, id2],
-          players: s.players.map((p) => ({ ...p, isLover: p.id === id1 || p.id === id2 })),
+        set((state) => {
+          const loversIds: [string, string] = [id1, id2];
+          const players = state.players.map((player) => ({
+            ...player,
+            isLover: player.id === id1 || player.id === id2,
+          }));
+          return {
+            loversIds,
+            players,
+            playerStatuses: derivePlayerStatuses({ ...state, players, loversIds }),
+          };
+        }),
+
+      addLog: (message) => set((state) => ({ log: [...state.log, message] })),
+      setLanguage: (lang) => set({ language: lang }),
+      setUiMode: (mode) => set({ uiMode: mode }),
+      togglePrivacyMode: () => set((state) => ({ privacyMode: !state.privacyMode })),
+
+      moveSeat: (playerId, direction) =>
+        set((state) => {
+          const seatOrder = normalizeSeatOrder(state.players, state.seatOrder);
+          const fromIndex = seatOrder.indexOf(playerId);
+          if (fromIndex === -1) return {};
+          const toIndex = fromIndex + (direction === 'up' ? -1 : 1);
+          if (toIndex < 0 || toIndex >= seatOrder.length) return {};
+          return { seatOrder: reorderArrayItem(seatOrder, fromIndex, toIndex) };
+        }),
+
+      setPlayerStatusFlag: (playerId, flag, value) =>
+        set((state) => {
+          const current = state.playerStatuses[playerId] ?? createDefaultPlayerStatus();
+          const nextValue = value ?? !current[flag];
+          const playerStatuses = {
+            ...state.playerStatuses,
+            [playerId]: {
+              ...current,
+              [flag]: nextValue,
+            },
+          };
+          const voteAssist =
+            flag === 'noVote' && state.voteAssist
+              ? {
+                  ...state.voteAssist,
+                  noVoteIds: nextValue
+                    ? [...new Set([...state.voteAssist.noVoteIds, playerId])]
+                    : state.voteAssist.noVoteIds.filter((id) => id !== playerId),
+                }
+              : state.voteAssist;
+          return { playerStatuses, voteAssist };
+        }),
+
+      toggleRoleReveal: (playerId) =>
+        set((state) => {
+          const current = state.playerStatuses[playerId] ?? createDefaultPlayerStatus();
+          return {
+            playerStatuses: {
+              ...state.playerStatuses,
+              [playerId]: {
+                ...current,
+                revealed: !current.revealed,
+              },
+            },
+          };
+        }),
+
+      undoLastAction: () => {
+        const state = get();
+        if (state.sessionSnapshots.length <= 1) return;
+        const sessionSnapshots = [...state.sessionSnapshots];
+        sessionSnapshots.pop();
+        const previous = sessionSnapshots[sessionSnapshots.length - 1];
+        if (!previous) return;
+        set({
+          ...cloneSessionState(previous.state),
+          savedSessions: state.savedSessions,
+          sessionSnapshots,
+        });
+      },
+
+      saveNamedSession: (name) =>
+        set((state) => {
+          const trimmed = name.trim();
+          if (!trimmed) return {};
+          const snapshot = captureSessionState(state);
+          const now = Date.now();
+          const existing = state.savedSessions.find((session) => session.name.toLowerCase() === trimmed.toLowerCase());
+          const savedSessions = existing
+            ? state.savedSessions.map((session) =>
+                session.id === existing.id
+                  ? { ...session, name: trimmed, updatedAt: now, state: snapshot }
+                  : session
+              )
+            : [
+                {
+                  id: `session-${now}-${Math.random().toString(36).slice(2, 8)}`,
+                  name: trimmed,
+                  createdAt: now,
+                  updatedAt: now,
+                  state: snapshot,
+                },
+                ...state.savedSessions,
+              ];
+          return { savedSessions };
+        }),
+
+      loadNamedSession: (sessionId) =>
+        set((state) => {
+          const session = state.savedSessions.find((candidate) => candidate.id === sessionId);
+          if (!session) return {};
+          const restored = cloneSessionState(session.state);
+          return {
+            ...restored,
+            savedSessions: state.savedSessions,
+            sessionSnapshots: [createSnapshot({ ...state, ...restored, savedSessions: state.savedSessions, sessionSnapshots: [] } as GameStore, `Load session ${session.name}`)],
+          };
+        }),
+
+      deleteNamedSession: (sessionId) =>
+        set((state) => ({
+          savedSessions: state.savedSessions.filter((session) => session.id !== sessionId),
         })),
 
-      addLog: (message) =>
-        set((s) => ({ log: [...s.log, message] })),
+      setVoteAssistActive: (active) =>
+        set((state) => {
+          const voteAssist = active ? buildVoteAssist(state.players, state.voteAssist) : null;
+          return {
+            voteAssist,
+            playerStatuses: derivePlayerStatuses({ ...state, voteAssist }),
+          };
+        }),
 
-      setLanguage: (lang) => set({ language: lang }),
+      adjustVote: (playerId, delta) =>
+        set((state) => {
+          if (!state.voteAssist) return {};
+          const currentVotes = state.voteAssist.votes[playerId] ?? 0;
+          return {
+            voteAssist: {
+              ...state.voteAssist,
+              votes: {
+                ...state.voteAssist.votes,
+                [playerId]: Math.max(0, currentVotes + delta),
+              },
+            },
+          };
+        }),
+
+      toggleNoVote: (playerId) =>
+        set((state) => {
+          if (!state.voteAssist) return {};
+          const noVoteIds = state.voteAssist.noVoteIds.includes(playerId)
+            ? state.voteAssist.noVoteIds.filter((id) => id !== playerId)
+            : [...state.voteAssist.noVoteIds, playerId];
+          const voteAssist = { ...state.voteAssist, noVoteIds };
+          return {
+            voteAssist,
+            playerStatuses: derivePlayerStatuses({ ...state, voteAssist }),
+          };
+        }),
+
+      resetVoteAssist: () =>
+        set((state) => ({
+          voteAssist: state.voteAssist ? buildVoteAssist(state.players) : null,
+        })),
+
+      clearResolutionQueue: () => set({ resolutionQueue: [] }),
     }),
     {
       name: 'loupgarous-game',
-      version: 2,
+      version: 3,
       migrate: (persistedState: unknown) => {
         if (!persistedState || typeof persistedState !== 'object') {
-          return persistedState as unknown as GameStore;
+          return persistedState as GameStore;
         }
 
-        const rest = { ...(persistedState as Record<string, unknown>) };
-        delete rest.votes;
-        return rest as unknown as GameStore;
+        const state = persistedState as Record<string, unknown>;
+        const players = Array.isArray(state.players) ? (state.players as Player[]) : [];
+        const nextState = {
+          ...state,
+          savedSessions: Array.isArray(state.savedSessions) ? state.savedSessions : [],
+          seatOrder: Array.isArray(state.seatOrder)
+            ? state.seatOrder
+            : players.map((player) => player.id),
+          playerStatuses:
+            state.playerStatuses && typeof state.playerStatuses === 'object'
+              ? state.playerStatuses
+              : Object.fromEntries(players.map((player) => [player.id, createDefaultPlayerStatus()])),
+          resolutionQueue: Array.isArray(state.resolutionQueue) ? state.resolutionQueue : [],
+          sessionSnapshots: [],
+          uiMode: (state.uiMode as UIMode | undefined) ?? 'prepare',
+          privacyMode: Boolean(state.privacyMode),
+          voteAssist: state.voteAssist ?? null,
+        };
+        delete (nextState as Record<string, unknown>).votes;
+        return nextState as unknown as GameStore;
       },
     }
   )

--- a/src/styles/day.css
+++ b/src/styles/day.css
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
-  padding: 1.1rem;
+  padding: 0;
 }
 
 .day-header {
@@ -41,6 +41,18 @@
   gap: 0.6rem;
   box-shadow: 0 12px 28px rgba(0,0,0,0.35);
 }
+.day-panel {
+  background: linear-gradient(120deg, rgba(255,255,255,0.02), rgba(255,255,255,0));
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem 1.1rem;
+}
+
+.day-trigger-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
 .day-triggers h3 { font-size: 0.95rem; font-weight: 700; margin-bottom: 0.2rem; }
 .day-trigger-item {
   font-size: 0.88rem;
@@ -55,7 +67,7 @@
 .day-players h3 { font-size: 1rem; font-weight: 700; margin-bottom: 0.7rem; }
 .players-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: 1fr;
   gap: 0.7rem;
 }
 
@@ -69,6 +81,46 @@
   flex-direction: column;
   gap: 0.8rem;
   box-shadow: 0 12px 28px rgba(0,0,0,0.35);
+}
+.vote-assist-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.vote-assist-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.vote-assist-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem 0.8rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,0.05);
+  background: rgba(255,255,255,0.03);
+}
+
+.vote-assist-row p {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin-top: 0.2rem;
+}
+
+.vote-assist-row--novote {
+  border-color: rgba(185,42,58,0.4);
+  background: rgba(185,42,58,0.08);
+}
+
+.vote-assist-actions {
+  display: flex;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 .voting-header {
   display: flex;
@@ -151,4 +203,21 @@
   font-size: 0.9rem;
   color: #f7cf5e;
   margin-bottom: 0.6rem;
+}
+
+@media (min-width: 760px) {
+  .players-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .vote-assist-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .vote-assist-actions {
+    justify-content: stretch;
+  }
 }

--- a/src/styles/gameboard.css
+++ b/src/styles/gameboard.css
@@ -37,7 +37,7 @@
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
-.alive-chip, .wolf-chip {
+.alive-chip, .wolf-chip, .queue-chip {
   font-size: 0.82rem;
   color: var(--text-muted);
 }
@@ -51,6 +51,9 @@
   border-bottom: 1px solid var(--border);
   background: rgba(14,9,20,0.9);
   backdrop-filter: blur(6px);
+  position: sticky;
+  top: 4.35rem;
+  z-index: 18;
 }
 .tabs-desktop {
   display: flex;
@@ -99,7 +102,7 @@
   border-radius: 12px;
   background: rgba(14,9,20,0.98);
   box-shadow: 0 14px 34px rgba(0,0,0,0.42);
-  z-index: 12;
+  z-index: 30;
 }
 .conf-menu-item {
   width: 100%;
@@ -129,6 +132,28 @@
   max-width: 780px;
   margin: 0 auto;
   width: 100%;
+  position: relative;
+}
+
+.privacy-on .tab-content > *:not(.privacy-overlay) {
+  filter: blur(12px);
+}
+
+.privacy-overlay {
+  position: absolute;
+  inset: 1rem;
+  z-index: 14;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.7rem;
+  border-radius: 18px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(8,6,12,0.84);
+  backdrop-filter: blur(16px);
+  text-align: center;
+  padding: 1.5rem;
 }
 
 /* Game Log */
@@ -137,6 +162,12 @@
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
+}
+.game-log-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
 }
 .game-log h3 { font-size: 1rem; font-weight: 800; margin-bottom: 0.35rem; letter-spacing: 0.06em; text-transform: uppercase; }
 .log-empty { color: var(--text-muted); font-size: 0.9rem; }
@@ -172,6 +203,20 @@
 .win-white_werewolf h2 { color: #e0e0e0; }
 .win-angel h2 { color: #f0c060; }
 .win-screen p { color: var(--text-muted); font-size: 1rem; letter-spacing: 0.04em; }
+.win-explainer {
+  max-width: 34rem;
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(255,255,255,0.04);
+}
+
+.win-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
 
 @media (max-width: 640px) {
   .gameboard-topbar {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -167,6 +167,196 @@ h1, h2, h3, h4 {
 .btn-large { padding: 0.85rem 1.6rem; font-size: 1.05rem; width: 100%; justify-content: center; }
 
 /* ===================================================
+   Shared Action Surface
+   =================================================== */
+.action-surface {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.action-surface__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.action-surface__header h2 {
+  font-size: 1.45rem;
+  font-weight: 800;
+}
+
+.action-surface__subtitle {
+  color: var(--text-muted);
+  font-size: 0.94rem;
+  line-height: 1.5;
+}
+
+.action-surface__metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.action-surface__metric {
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: rgba(255,255,255,0.03);
+  padding: 0.8rem 0.95rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  box-shadow: 0 10px 24px rgba(0,0,0,0.28);
+}
+
+.action-surface__metric strong {
+  font-size: 1.1rem;
+}
+
+.action-surface__metric-label {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.action-surface__metric--night { border-color: rgba(91,43,115,0.5); }
+.action-surface__metric--day { border-color: rgba(181,92,36,0.5); }
+.action-surface__metric--danger { border-color: rgba(185,42,58,0.55); }
+.action-surface__metric--success { border-color: rgba(74,161,138,0.55); }
+
+.action-surface__quick-panel,
+.day-panel,
+.setup-section,
+.night-summary,
+.night-step-content {
+  box-shadow: 0 14px 34px rgba(0,0,0,0.34);
+}
+
+.action-surface__quick-panel {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 0.9rem 1rem;
+  background: linear-gradient(145deg, rgba(255,255,255,0.035), rgba(255,255,255,0));
+}
+
+.gm-quick-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.gm-quick-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.gm-quick-panel__actions,
+.gm-quick-panel__stack {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.gm-quick-panel__hint {
+  color: var(--text-muted);
+  font-size: 0.88rem;
+}
+
+.action-surface__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.action-surface__footer {
+  position: sticky;
+  bottom: 0;
+  padding-bottom: max(0.5rem, env(safe-area-inset-bottom));
+  z-index: 9;
+}
+
+.sticky-action-bar {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.85rem;
+  border: 1px solid rgba(255,255,255,0.05);
+  border-radius: 18px;
+  background: rgba(9,7,15,0.92);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 16px 36px rgba(0,0,0,0.34);
+}
+
+.sticky-action-bar--split .btn:first-child {
+  flex: 0 0 auto;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.8rem;
+}
+
+.panel-kicker {
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.resolution-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.resolution-item {
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(255,255,255,0.03);
+  padding: 0.8rem 0.9rem;
+}
+
+.resolution-item strong {
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.resolution-item p {
+  color: var(--text-muted);
+  line-height: 1.45;
+}
+
+.resolution-item--death { border-color: rgba(185,42,58,0.42); }
+.resolution-item--save { border-color: rgba(74,161,138,0.42); }
+.resolution-item--chain,
+.resolution-item--status { border-color: rgba(181,92,36,0.42); }
+
+.setup-empty {
+  color: var(--text-muted);
+  font-size: 0.92rem;
+}
+
+@media (min-width: 768px) {
+  .action-surface__metrics {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* ===================================================
    Camp Colours
    =================================================== */
 .camp-village { border-color: var(--camp-village) !important; }

--- a/src/styles/night.css
+++ b/src/styles/night.css
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
-  padding: 1.1rem;
+  padding: 0;
 }
 
 .night-header {
@@ -187,6 +187,10 @@
   box-shadow: 0 12px 30px rgba(0,0,0,0.38);
 }
 .night-summary h3 { font-size: 1.2rem; font-weight: 800; }
+.night-summary-note {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
 
 /* New role elements */
 .role-wake-badges {
@@ -358,6 +362,22 @@
 .fox-result-summary--none {
   border-color: rgba(46,160,67,0.4);
   background: rgba(46,160,67,0.12);
+}
+
+@keyframes wakeCard {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.night-step-content,
+.night-summary {
+  animation: wakeCard 220ms ease-out;
 }
 
 /* Camp badge in seer reveal */

--- a/src/styles/player.css
+++ b/src/styles/player.css
@@ -6,7 +6,7 @@
   padding: 0.9rem 1.05rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
   transition: border-color 0.2s, opacity 0.2s, transform 0.2s;
   box-shadow: 0 12px 26px rgba(0,0,0,0.35);
 }
@@ -14,18 +14,32 @@
 .player-card.mayor { border-color: #c9a227; box-shadow: 0 0 0 1px rgba(201,162,39,0.2); }
 .player-card.lover { border-color: var(--camp-lovers); box-shadow: 0 0 0 1px rgba(216,92,159,0.18); }
 
+.player-card-main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
 .player-card-header {
   display: flex;
   align-items: center;
   gap: 0.5rem;
 }
+.player-card-identity {
+  flex: 1;
+  min-width: 0;
+}
 .player-emoji { font-size: 1.3rem; }
 .player-card-name {
   font-weight: 700;
   font-size: 0.95rem;
-  flex: 1;
+  display: block;
 }
 .player-badges { display: flex; gap: 0.3rem; flex-wrap: wrap; }
+.badge-status {
+  background: rgba(255,255,255,0.06);
+  color: var(--text);
+}
 
 .player-role {
   display: flex;
@@ -58,4 +72,11 @@
   display: flex;
   gap: 0.4rem;
   flex-wrap: wrap;
+}
+
+@media (max-width: 640px) {
+  .player-actions .btn {
+    flex: 1 1 calc(50% - 0.25rem);
+    justify-content: center;
+  }
 }

--- a/src/styles/setup.css
+++ b/src/styles/setup.css
@@ -92,6 +92,10 @@
   justify-content: space-between;
   flex-wrap: wrap;
 }
+.setup-kicker {
+  color: var(--text-muted);
+  font-size: 0.84rem;
+}
 .setup-section h2 {
   font-size: 1.08rem;
   font-weight: 800;
@@ -231,6 +235,57 @@
   color: var(--text);
 }
 
+.setup-main-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.setup-surface {
+  padding-inline: 0;
+}
+
+.setup-section--hero .quick-guide {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.session-save-row {
+  display: flex;
+  gap: 0.7rem;
+  align-items: center;
+}
+
+.saved-session-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.saved-session-card {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.8rem;
+  padding: 0.8rem 0.9rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: rgba(255,255,255,0.03);
+}
+
+.saved-session-card p {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  margin-top: 0.2rem;
+}
+
+.saved-session-actions {
+  display: flex;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
 /* Player count row */
 .player-count-row,
 .timer-config {
@@ -277,6 +332,33 @@
   padding: 0.55rem;
   border-radius: 10px;
   border: 1px solid rgba(255,255,255,0.03);
+}
+.seat-order-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.seat-order-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255,255,255,0.05);
+  background: rgba(255,255,255,0.03);
+}
+
+.seat-order-row p {
+  color: var(--text-muted);
+  font-size: 0.86rem;
+  margin-top: 0.2rem;
+}
+
+.seat-order-actions {
+  display: flex;
+  gap: 0.45rem;
 }
 .player-num {
   width: 24px;
@@ -343,6 +425,31 @@
 .optional-rule:hover { background: rgba(255,255,255,0.03); border-color: rgba(255,255,255,0.05); }
 .optional-rule input { margin-top: 3px; flex-shrink: 0; }
 
+.balance-notes {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.balance-note {
+  border-radius: 10px;
+  padding: 0.75rem 0.9rem;
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.balance-note--good {
+  background: rgba(74,161,138,0.12);
+  border: 1px solid rgba(74,161,138,0.4);
+  color: #96e5cf;
+}
+
+.balance-note--warn {
+  background: rgba(199,164,70,0.12);
+  border: 1px solid rgba(199,164,70,0.4);
+  color: #f3ce74;
+}
+
 /* Errors */
 .setup-errors {
   display: flex;
@@ -378,6 +485,17 @@
 .start-btn:hover:not(:disabled) { background: linear-gradient(145deg, #d94454, #8a1c2f); transform: translateY(-1px); }
 .start-btn:disabled { opacity: 0.35; cursor: not-allowed; box-shadow: none; }
 
+.setup-footer-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  width: 100%;
+}
+
+.setup-footer-actions .start-btn {
+  flex: 1;
+}
+
 .roles-tab-panel {
   background: var(--bg2);
   border: 1px solid var(--border);
@@ -399,4 +517,11 @@
 @media (max-width: 600px) {
   .player-row { flex-wrap: wrap; }
   .role-select { width: 100%; }
+  .session-save-row,
+  .setup-footer-actions,
+  .saved-session-card,
+  .seat-order-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }

--- a/src/types/game.types.ts
+++ b/src/types/game.types.ts
@@ -1,5 +1,6 @@
 export type Phase = 'setup' | 'night' | 'day';
 export type Language = 'en' | 'fr';
+export type UIMode = 'prepare' | 'run' | 'reference';
 export type Camp =
   | 'village'
   | 'werewolves'
@@ -92,7 +93,39 @@ export interface ProtectorRecord {
   targetId: string | null;
 }
 
-export interface GameState {
+export interface PlayerStatus {
+  protected: boolean;
+  cursed: boolean;
+  silenced: boolean;
+  noVote: boolean;
+  cannotBeProtected: boolean;
+  enchanted: boolean;
+  infected: boolean;
+  lovers: boolean;
+  mayor: boolean;
+  roleLocked: boolean;
+  revealed: boolean;
+  transformed: boolean;
+}
+
+export interface ResolutionItem {
+  id: string;
+  round: number;
+  phase: Exclude<Phase, 'setup'>;
+  type: 'death' | 'save' | 'chain' | 'reminder' | 'status' | 'vote';
+  title: string;
+  detail: string;
+  playerIds: string[];
+  public: boolean;
+}
+
+export interface VoteState {
+  active: boolean;
+  votes: Record<string, number>;
+  noVoteIds: string[];
+}
+
+export interface SessionState {
   phase: Phase;
   round: number;
   players: Player[];
@@ -122,4 +155,29 @@ export interface GameState {
   protectorHistory: ProtectorRecord[];   // records per-night Protector targets
   protectedPlayerId: string | null;      // player protected by Protector for the current night
   lastProtectedPlayerId: string | null;  // player protected on the previous night
+  seatOrder: string[];
+  playerStatuses: Record<string, PlayerStatus>;
+  resolutionQueue: ResolutionItem[];
+  uiMode: UIMode;
+  privacyMode: boolean;
+  voteAssist: VoteState | null;
+}
+
+export interface SessionSnapshot {
+  id: string;
+  reason: string;
+  createdAt: number;
+  state: SessionState;
+}
+
+export interface SavedSession {
+  id: string;
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+  state: SessionState;
+}
+
+export interface GameState extends SessionState {
+  sessionSnapshots: SessionSnapshot[];
 }

--- a/tests/e2e/phone-first-gm.spec.ts
+++ b/tests/e2e/phone-first-gm.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test';
+
+const ROLE_PRESET = ['werewolf', 'werewolf', 'villager', 'villager', 'villager', 'villager'];
+
+async function assignBaseRoles(page: import('@playwright/test').Page) {
+  for (const [index, roleId] of ROLE_PRESET.entries()) {
+    const row = page.getByTestId(`player-row-${index}`);
+    await row.getByTestId('role-select').selectOption(roleId);
+  }
+}
+
+test.describe('phone-first GM flow', () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('prepare mode supports seat ordering and setup saves', async ({ page }) => {
+    await page.goto('./');
+
+    await page.getByTestId('player-row-0').getByRole('textbox').fill('Alice');
+    await page.getByTestId('player-row-1').getByRole('textbox').fill('Bob');
+
+    await expect(page.getByTestId('seat-order-row-0')).toContainText('Alice');
+    await page.getByTestId('seat-order-row-0').getByRole('button', { name: '↓' }).click();
+    await expect(page.getByTestId('seat-order-row-0')).toContainText('Bob');
+    await expect(page.getByTestId('seat-order-row-1')).toContainText('Alice');
+
+    await page.getByTestId('session-name-input').fill('Prep Table');
+    await page.getByTestId('save-session').click();
+    await expect(page.getByTestId('saved-session-card')).toContainText('Prep Table');
+  });
+
+  test('run mode supports privacy toggle and loading a saved live session', async ({ page }) => {
+    await page.goto('./');
+    await assignBaseRoles(page);
+    await page.getByTestId('start-game').click();
+
+    await expect(page.getByTestId('night-phase')).toBeVisible();
+    await page.getByTestId('privacy-toggle').click();
+    await expect(page.getByText(/Privacy mode is active|mode confidentialité/i)).toBeVisible();
+    await page.getByTestId('privacy-toggle').click();
+    await expect(page.getByText(/Privacy mode is active|mode confidentialité/i)).not.toBeVisible();
+
+    page.once('dialog', async (dialog) => {
+      expect(dialog.type()).toBe('prompt');
+      await dialog.accept('Live Save');
+    });
+    await page.getByTestId('save-live-session').click();
+
+    page.once('dialog', async (dialog) => {
+      expect(dialog.type()).toBe('confirm');
+      await dialog.accept();
+    });
+    await page.getByRole('button', { name: /Setup|Préparation/i }).click();
+
+    await expect(page.getByTestId('setup-main-tab')).toBeVisible();
+    const savedCard = page.getByTestId('saved-session-card').filter({ hasText: 'Live Save' });
+    await expect(savedCard).toBeVisible();
+    await savedCard.getByRole('button', { name: /Load|Charger/i }).click();
+    await expect(page.getByTestId('night-phase')).toBeVisible();
+  });
+
+  test('day mode vote assist tracks totals, no-vote states, and ties', async ({ page }) => {
+    await page.goto('./');
+    await assignBaseRoles(page);
+    await page.getByTestId('start-game').click();
+    await page.getByTestId('night-next').click();
+    await page.getByTestId('reveal-day').click();
+
+    await expect(page.getByTestId('day-phase')).toBeVisible();
+    await page.getByTestId('vote-assist-toggle').click();
+    await expect(page.getByRole('heading', { name: /Vote Assist|Assistant de vote/i })).toBeVisible();
+
+    const firstRow = page.locator('.vote-assist-row').first();
+    await firstRow.getByRole('button', { name: '+1' }).click();
+    await firstRow.getByRole('button', { name: /Mayor \+2|Maire \+2/i }).click();
+    await expect(firstRow).toContainText(/Total against: 3|Total contre : 3/i);
+    await firstRow.getByRole('button', { name: /No vote|Sans vote/i }).click();
+    await expect(firstRow.getByRole('button', { name: /Allow vote|Autoriser/i })).toBeVisible();
+
+    const secondRow = page.locator('.vote-assist-row').nth(1);
+    await secondRow.getByRole('button', { name: '+1' }).click();
+    await secondRow.getByRole('button', { name: /Mayor \+2|Maire \+2/i }).click();
+    await expect(page.getByText(/Tie detected|Égalité détectée/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- refactor the app around a phone-first GM flow with shared action surfaces
- add seat order, player statuses, resolution queue, undo snapshots, vote assist, privacy mode, and named sessions to the store
- redesign setup/day/night for faster live moderation and add mobile-first Playwright coverage

## Verification
- `npm run build`
- `npx playwright test tests/e2e/phone-first-gm.spec.ts tests/e2e/mobile-gameboard-nav.spec.ts tests/e2e/base-game-flow.spec.ts tests/e2e/white-wolf-endgame.spec.ts`