### PR TITLE
Replace table preview with role tray

### DIFF
--- a/src/components/Setup/SetupScreen.tsx
+++ b/src/components/Setup/SetupScreen.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, type CSSProperties } from 'react';
+import { useState, useCallback } from 'react';
 import { useGameStore } from '../../store/gameStore';
 import { SETUP_ROLE_IDS, SETUP_ROLES, getRoleName, getRoleTexts } from '../../data/roles';
 import RoleReference from '../Roles/RoleReference';
@@ -296,25 +296,24 @@ export default function SetupScreen() {
           </section>
 
           <section className="setup-section">
-            <h2>◯ {t.setup.tablePreview}</h2>
-            <div className="table-preview" data-testid="table-preview">
+            <h2>▣ {t.setup.roleTray}</h2>
+            <div className="role-tray" data-testid="role-tray" aria-label={t.setup.roleTray}>
               {roleAssignment.slice(0, playerCount).map((roleId, i) => {
                 const role = SETUP_ROLES.find((r) => r.id === roleId);
-                const style = {
-                  '--seat-index': i,
-                  '--seat-count': playerCount,
-                } as CSSProperties;
+                const roleName = role ? getRoleName(role, language) : roleId;
                 return (
                   <div
                     key={`${roleId}-${i}`}
-                    className={`table-seat camp-${role?.camp ?? 'neutral'}`}
-                    style={style}
-                    data-testid={`table-seat-${i}`}
+                    className={`role-tray-chip camp-${role?.camp ?? 'neutral'}`}
+                    data-testid={`role-tray-seat-${i}`}
+                    title={`#${i + 1} ${roleName}`}
+                    aria-label={`#${i + 1} ${roleName}`}
                   >
-                    <span className="table-seat-number">#{i + 1}</span>
-                    <span className="table-seat-role">
-                      {role ? `${role.emoji} ${getRoleName(role, language)}` : roleId}
+                    <span className="role-tray-number">#{i + 1}</span>
+                    <span className="role-tray-emoji" aria-hidden="true">
+                      {role?.emoji ?? '❔'}
                     </span>
+                    <span className="sr-only">{roleName}</span>
                   </div>
                 );
               })}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -15,7 +15,7 @@ interface Strings {
     discussionTimer: string;
     optionalRules: string;
     orderedRoles: string;
-    tablePreview: string;
+    roleTray: string;
     addRole: string;
     removeRole: string;
     moveUp: string;
@@ -274,7 +274,7 @@ const translations: Record<Language, Strings> = {
       discussionTimer: 'Discussion Timer',
       optionalRules: 'Optional Rules',
       orderedRoles: 'Ordered Roles',
-      tablePreview: 'Table Order',
+      roleTray: 'Role Tray',
       addRole: 'Add role',
       removeRole: 'Remove role',
       moveUp: 'Move up',
@@ -578,7 +578,7 @@ const translations: Record<Language, Strings> = {
       discussionTimer: 'Minuteur de discussion',
       optionalRules: 'Règles optionnelles',
       orderedRoles: 'Rôles ordonnés',
-      tablePreview: 'Ordre de table',
+      roleTray: 'Plateau des rôles',
       addRole: 'Ajouter un rôle',
       removeRole: 'Retirer le rôle',
       moveUp: 'Monter',

--- a/src/styles/setup.css
+++ b/src/styles/setup.css
@@ -336,61 +336,53 @@
   align-self: flex-start;
 }
 
-.table-preview {
-  position: relative;
-  min-height: 360px;
+.role-tray {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(54px, 1fr));
+  gap: 0.45rem;
+  padding: 0.65rem;
   border: 1px solid rgba(255,255,255,0.06);
-  border-radius: 14px;
-  background:
-    radial-gradient(circle at 50% 50%, rgba(185,42,58,0.12) 0 27%, transparent 28%),
-    radial-gradient(circle at 50% 50%, rgba(255,255,255,0.03) 0 46%, transparent 47%);
-  overflow: hidden;
+  border-radius: 12px;
+  background: rgba(0,0,0,0.14);
 }
-.table-preview::before {
-  content: '';
-  position: absolute;
-  inset: 34%;
-  border-radius: 999px;
-  border: 1px solid rgba(255,255,255,0.08);
-  background: rgba(0,0,0,0.12);
-}
-.table-seat {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  width: clamp(92px, 18vw, 132px);
-  min-height: 54px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 0.2rem;
-  padding: 0.45rem 0.55rem;
+.role-tray-chip {
+  min-width: 0;
+  min-height: 52px;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  place-items: center;
+  gap: 0.1rem;
+  padding: 0.35rem 0.25rem;
   border: 1px solid var(--border);
   border-radius: 8px;
-  background: rgba(14,9,20,0.92);
-  transform:
-    translate(-50%, -50%)
-    rotate(calc(360deg / var(--seat-count) * var(--seat-index) - 90deg))
-    translateY(clamp(-140px, -28vw, -112px))
-    rotate(calc(-360deg / var(--seat-count) * var(--seat-index) + 90deg));
-  box-shadow: 0 10px 20px rgba(0,0,0,0.32);
+  background: rgba(14,9,20,0.9);
+  box-shadow: 0 8px 16px rgba(0,0,0,0.28);
 }
-.table-seat-number {
+.role-tray-number {
   color: #f8e6d8;
   font-weight: 800;
-  font-size: 0.78rem;
+  font-size: 0.68rem;
+  line-height: 1;
 }
-.table-seat-role {
-  color: var(--text);
-  font-size: 0.78rem;
-  font-weight: 700;
-  line-height: 1.2;
-  overflow-wrap: anywhere;
+.role-tray-emoji {
+  font-size: 1.35rem;
+  line-height: 1;
 }
-.table-seat.camp-village { border-color: rgba(46,160,67,0.5); }
-.table-seat.camp-werewolves { border-color: rgba(218,54,51,0.55); }
-.table-seat.camp-ambiguous { border-color: rgba(110,118,129,0.55); }
-.table-seat.camp-loner { border-color: rgba(147,51,234,0.55); }
+.role-tray-chip.camp-village { border-color: rgba(46,160,67,0.5); }
+.role-tray-chip.camp-werewolves { border-color: rgba(218,54,51,0.55); }
+.role-tray-chip.camp-ambiguous { border-color: rgba(110,118,129,0.55); }
+.role-tray-chip.camp-loner { border-color: rgba(147,51,234,0.55); }
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 
 /* Role summary */
 .role-summary {
@@ -483,13 +475,7 @@
   .role-select { width: 100%; }
   .role-slot-label { width: 100%; }
   .role-slot-actions { width: 100%; justify-content: flex-end; }
-  .table-preview { min-height: 420px; }
-  .table-seat {
-    width: 92px;
-    transform:
-      translate(-50%, -50%)
-      rotate(calc(360deg / var(--seat-count) * var(--seat-index) - 90deg))
-      translateY(-165px)
-      rotate(calc(-360deg / var(--seat-count) * var(--seat-index) + 90deg));
-  }
+  .role-tray { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+  .role-tray-chip { min-height: 48px; }
+  .role-tray-emoji { font-size: 1.25rem; }
 }

--- a/tests/e2e/role-first-workflow.spec.ts
+++ b/tests/e2e/role-first-workflow.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test('role-first setup uses ordered seats, table preview, and seat labels', async ({ page }) => {
+test('role-first setup uses ordered seats, role tray, and seat labels', async ({ page }) => {
   await page.goto('/');
 
   await expect(page.getByTestId('player-row-0').getByRole('textbox')).toHaveCount(0);
@@ -15,11 +15,11 @@ test('role-first setup uses ordered seats, table preview, and seat labels', asyn
   await page.getByTestId('player-row-3').getByTestId('role-select').selectOption('villager');
   await expect(page.getByTestId('player-row-4').getByTestId('role-select')).toContainText('Cupid');
 
-  await expect(page.getByTestId('table-preview')).toContainText('#1');
-  await expect(page.getByTestId('table-seat-1')).toContainText('Fox');
+  await expect(page.getByTestId('role-tray')).toContainText('#1');
+  await expect(page.getByTestId('role-tray-seat-1')).toHaveAttribute('aria-label', /Fox/);
 
   await page.getByTestId('move-seat-down-1').click();
-  await expect(page.getByTestId('table-seat-2')).toContainText('Fox');
+  await expect(page.getByTestId('role-tray-seat-2')).toHaveAttribute('aria-label', /Fox/);
 
   await page.getByTestId('add-role-slot').click();
   await expect(page.getByTestId('player-row-6')).toBeVisible();


### PR DESCRIPTION
## Summary
- replace the circular setup table preview with a compact role tray for mobile
- keep ordered seat numbers and role icons visible in the tray
- update EN/FR copy and E2E expectations

## Verification
- npm run lint
- npm run build
- npm run test:e2e