### PR TITLE
Fix role-flow review issues

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <external-path name="my_images" path="." />
     <cache-path name="my_cache_images" path="." />
 </paths>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:4173';
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:4173';
 const useExternalBaseUrl = process.env.PLAYWRIGHT_SKIP_WEBSERVER === '1';
 
 export default defineConfig({
@@ -26,8 +26,8 @@ export default defineConfig({
   webServer: useExternalBaseUrl
     ? undefined
     : {
-        command: 'npm run dev -- --host 0.0.0.0 --port 4173 --strictPort',
-        url: 'http://localhost:4173',
+        command: 'npm run dev -- --host 127.0.0.1 --port 4173 --strictPort',
+        url: 'http://127.0.0.1:4173',
         reuseExistingServer: !process.env.CI,
         timeout: 120_000,
       },

--- a/src/components/Game/DayPhase.tsx
+++ b/src/components/Game/DayPhase.tsx
@@ -19,6 +19,7 @@ export default function DayPhase() {
   const wolfDogChoice = useGameStore((s) => s.wolfDogChoice);
   const foxPowerActive = useGameStore((s) => s.foxPowerActive);
   const usedGameAbilities = useGameStore((s) => s.usedGameAbilities);
+  const rolePowerOverrides = useGameStore((s) => s.rolePowerOverrides ?? {});
 
   const eliminatePlayer = useGameStore((s) => s.eliminatePlayer);
   const addLog = useGameStore((s) => s.addLog);
@@ -71,6 +72,7 @@ export default function DayPhase() {
 
   const mayorAlive = players.find((p) => p.isAlive && p.isMayor) ?? null;
   const foxInGame = players.some((p) => p.roleId === 'fox');
+  const foxEffectivePowerActive = rolePowerOverrides.fox ?? foxPowerActive;
   const witchInGame = players.some((p) => p.roleId === 'witch' && p.isAlive);
   const witchHealUsed = usedGameAbilities.includes('witch_heal');
   const witchPoisonUsed = usedGameAbilities.includes('witch_poison');
@@ -152,7 +154,7 @@ export default function DayPhase() {
 
       {foxInGame && (
         <div className="day-trigger-item">
-          {foxPowerActive ? t.day.foxPowerActive : t.day.foxPowerLost}
+          {foxEffectivePowerActive ? t.day.foxPowerActive : t.day.foxPowerLost}
         </div>
       )}
 

--- a/src/components/Game/GameBoard.tsx
+++ b/src/components/Game/GameBoard.tsx
@@ -74,6 +74,7 @@ export default function GameBoard() {
   const wolvesWin =
     packWolfCount > 0 &&
     packWolfCount >= villageCount &&
+    !whiteWolfAlive &&
     !piedPiperWins &&
     !whiteWolfWins &&
     !angelWon;

--- a/src/components/Setup/SetupScreen.tsx
+++ b/src/components/Setup/SetupScreen.tsx
@@ -1,6 +1,6 @@
-import { useState, useCallback, type CSSProperties } from 'react';
+import { useState, useCallback } from 'react';
 import { useGameStore } from '../../store/gameStore';
-import { SETUP_ROLE_IDS, SETUP_ROLES, getRoleName, getRoleTexts } from '../../data/roles';
+import { SETUP_ROLE_IDS, SETUP_ROLES, WOLF_ROLE_IDS, getRoleName, getRoleTexts } from '../../data/roles';
 import RoleReference from '../Roles/RoleReference';
 import LanguageToggle from '../LanguageToggle';
 import QuickGuide from './QuickGuide';
@@ -106,16 +106,18 @@ export default function SetupScreen() {
 
   // Validation
   const errors: string[] = [];
-  Object.entries(roleCounts).forEach(([id, count]) => {
-    const def = SETUP_ROLES.find((r) => r.id === id);
-    if (!def) return;
+  SETUP_ROLES.forEach((def) => {
+    const count = roleCounts[def.id] ?? 0;
     const roleLabel = getRoleName(def, language);
     if (count > def.maxCount)
       errors.push(t.setup.errors.tooMany(roleLabel, def.maxCount));
     if (count < def.minCount)
       errors.push(t.setup.errors.notEnough(roleLabel, def.minCount));
   });
-  const wolfSideCount = (roleCounts['werewolf'] ?? 0) + (roleCounts['white_werewolf'] ?? 0);
+  const wolfSideCount = [...WOLF_ROLE_IDS, 'white_werewolf'].reduce(
+    (count, roleId) => count + (roleCounts[roleId] ?? 0),
+    0
+  );
   if (wolfSideCount === 0)
     errors.push(t.setup.errors.needWolf);
   const sistersDef = SETUP_ROLES.find((r) => r.id === 'soeurs');
@@ -293,32 +295,6 @@ export default function SetupScreen() {
             >
               + {t.setup.addRole}
             </button>
-          </section>
-
-          <section className="setup-section">
-            <h2>◯ {t.setup.tablePreview}</h2>
-            <div className="table-preview" data-testid="table-preview">
-              {roleAssignment.slice(0, playerCount).map((roleId, i) => {
-                const role = SETUP_ROLES.find((r) => r.id === roleId);
-                const style = {
-                  '--seat-index': i,
-                  '--seat-count': playerCount,
-                } as CSSProperties;
-                return (
-                  <div
-                    key={`${roleId}-${i}`}
-                    className={`table-seat camp-${role?.camp ?? 'neutral'}`}
-                    style={style}
-                    data-testid={`table-seat-${i}`}
-                  >
-                    <span className="table-seat-number">#{i + 1}</span>
-                    <span className="table-seat-role">
-                      {role ? `${role.emoji} ${getRoleName(role, language)}` : roleId}
-                    </span>
-                  </div>
-                );
-              })}
-            </div>
           </section>
 
           {/* Role Summary */}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -15,7 +15,6 @@ interface Strings {
     discussionTimer: string;
     optionalRules: string;
     orderedRoles: string;
-    tablePreview: string;
     addRole: string;
     removeRole: string;
     moveUp: string;
@@ -274,7 +273,6 @@ const translations: Record<Language, Strings> = {
       discussionTimer: 'Discussion Timer',
       optionalRules: 'Optional Rules',
       orderedRoles: 'Ordered Roles',
-      tablePreview: 'Table Order',
       addRole: 'Add role',
       removeRole: 'Remove role',
       moveUp: 'Move up',
@@ -578,7 +576,6 @@ const translations: Record<Language, Strings> = {
       discussionTimer: 'Minuteur de discussion',
       optionalRules: 'Règles optionnelles',
       orderedRoles: 'Rôles ordonnés',
-      tablePreview: 'Ordre de table',
       addRole: 'Ajouter un rôle',
       removeRole: 'Retirer le rôle',
       moveUp: 'Monter',

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -8,7 +8,13 @@ import type {
   Language,
   Player as GamePlayer,
 } from '../types/game.types';
-import { getNightOrder, isPlayerWolfIdentity, WOLF_ROLE_IDS } from '../data/roles';
+import {
+  getNightOrder,
+  isPlayerWolfIdentity,
+  REMOVED_ROLE_IDS,
+  SETUP_ROLE_IDS,
+  WOLF_ROLE_IDS,
+} from '../data/roles';
 import { getStrings } from '../i18n';
 import { getPlayerRoleLabelById } from '../utils/playerLabels';
 
@@ -81,6 +87,7 @@ const defaultGame: GameState = {
   enchantedPlayerIds: [],
   infectedPlayerIds: [],
   angelWon: false,
+  firstDayExecutionDone: false,
   language: 'en',
   protectedPlayerId: null,
   lastProtectedPlayerId: null,
@@ -129,6 +136,17 @@ export function isNightRoleAvailable(roleId: string, context: NightStepContext) 
 
 function buildNightSteps(context: NightStepContext): NightStep[] {
   const roleIds = [...new Set(context.players.filter((p) => p.isAlive).map((p) => p.roleId))];
+  const hasPackWolf = context.players.some(
+    (p) =>
+      p.isAlive &&
+      p.roleId !== 'white_werewolf' &&
+      isPlayerWolfIdentity(p, {
+        infectedPlayerIds: context.infectedPlayerIds,
+        wolfDogChoice: context.wolfDogChoice,
+        wildChildTransformed: context.wildChildTransformed,
+      })
+  );
+  if (hasPackWolf && !roleIds.includes('werewolf')) roleIds.push('werewolf');
 
   return getNightOrder(roleIds, context.round, true)
     .filter((r) => isNightRoleAvailable(r.id, context))
@@ -194,7 +212,8 @@ export function resolveNightEliminations(
   eliminatedThisNight: string[],
   infectedPlayerIds: string[],
   loversIds: [string, string] | null,
-  language: Language = 'en'
+  language: Language = 'en',
+  eliminationCauses: Record<string, 'wolves' | 'other'> = {}
 ) {
   const finalEliminated = [...eliminatedThisNight];
   let knightLog = '';
@@ -202,7 +221,11 @@ export function resolveNightEliminations(
   const labelFor = (id: string) => getPlayerRoleLabelById(id, players, language);
 
   const knightPlayer = players.find((p) => p.isAlive && p.roleId === 'knight');
-  if (knightPlayer && finalEliminated.includes(knightPlayer.id)) {
+  if (
+    knightPlayer &&
+    finalEliminated.includes(knightPlayer.id) &&
+    eliminationCauses[knightPlayer.id] === 'wolves'
+  ) {
     const total = players.length;
     const knightIdx = players.findIndex((p) => p.id === knightPlayer.id);
     for (let offset = 1; offset < total; offset++) {
@@ -297,6 +320,7 @@ export const useGameStore = create<GameStore>()(
           enchantedPlayerIds: [],
           infectedPlayerIds: [],
           angelWon: false,
+          firstDayExecutionDone: false,
           language: language ?? 'en',
           protectedPlayerId: null,
           lastProtectedPlayerId: null,
@@ -587,7 +611,16 @@ export const useGameStore = create<GameStore>()(
         set((s) => ({ timerRemaining: s.discussionTimeSeconds, timerRunning: false })),
 
       eliminatePlayer: (id) => {
-        const { players, loversIds, log, round, wildChildModelId, wildChildTransformed } = get();
+        const {
+          phase,
+          players,
+          loversIds,
+          log,
+          round,
+          wildChildModelId,
+          wildChildTransformed,
+          firstDayExecutionDone,
+        } = get();
         const strings = getStrings(get().language);
         const language = get().language;
         const toElim = [id];
@@ -596,6 +629,13 @@ export const useGameStore = create<GameStore>()(
           if (other) toElim.push(other);
         }
         const updated = players.map((p) => toElim.includes(p.id) ? { ...p, isAlive: false } : p);
+        const isFirstDayExecution = phase === 'day' && round === 1 && !firstDayExecutionDone;
+        const executedPlayer = players.find((p) => p.id === id);
+        const angelWins = isFirstDayExecution && executedPlayer?.roleId === 'angel';
+        const finalPlayers =
+          isFirstDayExecution && !angelWins
+            ? updated.map((p) => (p.isAlive && p.roleId === 'angel' ? { ...p, roleId: 'villager' } : p))
+            : updated;
         const newWildChildTransformed =
           wildChildTransformed ||
           (wildChildModelId !== null && toElim.includes(wildChildModelId));
@@ -604,8 +644,10 @@ export const useGameStore = create<GameStore>()(
           .filter(Boolean)
           .join(' & ');
         set({
-          players: updated,
+          players: finalPlayers,
           wildChildTransformed: newWildChildTransformed,
+          angelWon: angelWins || get().angelWon,
+          firstDayExecutionDone: firstDayExecutionDone || isFirstDayExecution,
           log: [
             ...log,
             strings.logs.dayElimination(round, elimNames),
@@ -639,18 +681,87 @@ export const useGameStore = create<GameStore>()(
         }
 
         const rest = { ...(persistedState as Record<string, unknown>) };
+        const sanitizeRoleId = (roleId: unknown) =>
+          typeof roleId === 'string' && SETUP_ROLE_IDS.has(roleId) && !REMOVED_ROLE_IDS.has(roleId)
+            ? roleId
+            : 'villager';
+        const normalizePlayer = (player: unknown, index: number) => {
+          const raw = player && typeof player === 'object' ? player as Record<string, unknown> : {};
+          return {
+            ...raw,
+            id: typeof raw.id === 'string' ? raw.id : `p${index}`,
+            name: typeof raw.name === 'string' ? raw.name : '',
+            seatNumber: typeof raw.seatNumber === 'number' ? raw.seatNumber : index + 1,
+            roleId: sanitizeRoleId(raw.roleId),
+            isAlive: typeof raw.isAlive === 'boolean' ? raw.isAlive : true,
+            isMayor: typeof raw.isMayor === 'boolean' ? raw.isMayor : false,
+            isLover: typeof raw.isLover === 'boolean' ? raw.isLover : false,
+            extraVotes: typeof raw.extraVotes === 'number' ? raw.extraVotes : 0,
+            usedAbilities: Array.isArray(raw.usedAbilities) ? raw.usedAbilities : [],
+          } as Player;
+        };
+        const normalizeOverrides = (value: unknown) => {
+          if (!value || typeof value !== 'object') return {};
+          return Object.fromEntries(
+            Object.entries(value as Record<string, unknown>).filter(
+              ([roleId, active]) => SETUP_ROLE_IDS.has(roleId) && typeof active === 'boolean'
+            )
+          ) as Record<string, boolean>;
+        };
+        const normalizeProtectorHistory = (value: unknown) =>
+          Array.isArray(value)
+            ? value
+              .map((entry) => {
+                const raw = entry && typeof entry === 'object' ? entry as Record<string, unknown> : {};
+                return {
+                  round: typeof raw.round === 'number' ? raw.round : 0,
+                  targetId: typeof raw.targetId === 'string' ? raw.targetId : null,
+                };
+              })
+              .filter((entry) => entry.round > 0)
+            : [];
+
         delete rest.votes;
-        if (!rest.rolePowerOverrides || typeof rest.rolePowerOverrides !== 'object') {
-          rest.rolePowerOverrides = {};
-        }
+        rest.rolePowerOverrides = normalizeOverrides(rest.rolePowerOverrides);
+        if (typeof rest.firstDayExecutionDone !== 'boolean') rest.firstDayExecutionDone = false;
+        if (Array.isArray(rest.roleIds)) rest.roleIds = rest.roleIds.map(sanitizeRoleId);
         if (Array.isArray(rest.players)) {
-          rest.players = rest.players.map((player, index) => ({
-            ...(player as Record<string, unknown>),
-            seatNumber:
-              typeof (player as Record<string, unknown>).seatNumber === 'number'
-                ? (player as Record<string, unknown>).seatNumber
-                : index + 1,
-          }));
+          rest.players = rest.players.map(normalizePlayer);
+        }
+        if (Array.isArray(rest.nightSteps)) {
+          rest.nightSteps = rest.nightSteps.filter((step) => {
+            const roleId = step && typeof step === 'object'
+              ? (step as Record<string, unknown>).roleId
+              : null;
+            return typeof roleId === 'string' && SETUP_ROLE_IDS.has(roleId);
+          });
+        }
+        if (Array.isArray(rest.nightStepStates)) {
+          rest.nightStepStates = rest.nightStepStates.map((snapshot) => {
+            const raw = snapshot && typeof snapshot === 'object'
+              ? snapshot as Record<string, unknown>
+              : {};
+            return {
+              ...raw,
+              eliminatedThisNight: Array.isArray(raw.eliminatedThisNight) ? raw.eliminatedThisNight : [],
+              usedGameAbilities: Array.isArray(raw.usedGameAbilities) ? raw.usedGameAbilities : [],
+              enchantedPlayerIds: Array.isArray(raw.enchantedPlayerIds) ? raw.enchantedPlayerIds : [],
+              infectedPlayerIds: Array.isArray(raw.infectedPlayerIds) ? raw.infectedPlayerIds : [],
+              loversIds: Array.isArray(raw.loversIds) && raw.loversIds.length === 2
+                ? raw.loversIds as [string, string]
+                : null,
+              players: Array.isArray(raw.players) ? raw.players.map(normalizePlayer) : [],
+              foxPowerActive: typeof raw.foxPowerActive === 'boolean' ? raw.foxPowerActive : true,
+              wildChildModelId: typeof raw.wildChildModelId === 'string' ? raw.wildChildModelId : null,
+              wolfDogChoice: raw.wolfDogChoice === 'villager' || raw.wolfDogChoice === 'werewolf'
+                ? raw.wolfDogChoice
+                : null,
+              protectorHistory: normalizeProtectorHistory(raw.protectorHistory),
+              protectedPlayerId: typeof raw.protectedPlayerId === 'string' ? raw.protectedPlayerId : null,
+              lastProtectedPlayerId: typeof raw.lastProtectedPlayerId === 'string' ? raw.lastProtectedPlayerId : null,
+              rolePowerOverrides: normalizeOverrides(raw.rolePowerOverrides),
+            } satisfies NightStepState;
+          });
         }
         return rest as unknown as GameStore;
       },

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -221,10 +221,13 @@ export function resolveNightEliminations(
   const labelFor = (id: string) => getPlayerRoleLabelById(id, players, language);
 
   const knightPlayer = players.find((p) => p.isAlive && p.roleId === 'knight');
+  const knightEliminationCause = knightPlayer
+    ? eliminationCauses[knightPlayer.id] ?? 'wolves'
+    : undefined;
   if (
     knightPlayer &&
     finalEliminated.includes(knightPlayer.id) &&
-    eliminationCauses[knightPlayer.id] === 'wolves'
+    knightEliminationCause === 'wolves'
   ) {
     const total = players.length;
     const knightIdx = players.findIndex((p) => p.id === knightPlayer.id);
@@ -720,21 +723,51 @@ export const useGameStore = create<GameStore>()(
               })
               .filter((entry) => entry.round > 0)
             : [];
+        const normalizeLoversIds = (value: unknown) =>
+          Array.isArray(value) &&
+          value.length === 2 &&
+          typeof value[0] === 'string' &&
+          typeof value[1] === 'string'
+            ? value as [string, string]
+            : null;
 
         delete rest.votes;
         rest.rolePowerOverrides = normalizeOverrides(rest.rolePowerOverrides);
         if (typeof rest.firstDayExecutionDone !== 'boolean') rest.firstDayExecutionDone = false;
+        rest.loversIds = normalizeLoversIds(rest.loversIds);
         if (Array.isArray(rest.roleIds)) rest.roleIds = rest.roleIds.map(sanitizeRoleId);
         if (Array.isArray(rest.players)) {
           rest.players = rest.players.map(normalizePlayer);
         }
         if (Array.isArray(rest.nightSteps)) {
-          rest.nightSteps = rest.nightSteps.filter((step) => {
-            const roleId = step && typeof step === 'object'
-              ? (step as Record<string, unknown>).roleId
-              : null;
-            return typeof roleId === 'string' && SETUP_ROLE_IDS.has(roleId);
-          });
+          const currentNightStepIndex =
+            typeof rest.currentNightStepIndex === 'number'
+              ? Math.max(0, rest.currentNightStepIndex)
+              : 0;
+          let adjustedCurrentNightStepIndex = 0;
+          const nightSteps = rest.nightSteps.flatMap((step, originalIndex) => {
+            const raw = step && typeof step === 'object'
+              ? step as Record<string, unknown>
+              : {};
+            const roleId = raw.roleId;
+            if (
+              typeof roleId !== 'string' ||
+              !SETUP_ROLE_IDS.has(roleId) ||
+              REMOVED_ROLE_IDS.has(roleId)
+            ) return [];
+            if (originalIndex < currentNightStepIndex) adjustedCurrentNightStepIndex += 1;
+            return [{
+              ...raw,
+              roleId,
+              stepIndex: 0,
+            }];
+          }).map((step, index) => ({
+            ...step,
+            stepIndex: index,
+            completed: index < adjustedCurrentNightStepIndex,
+          }));
+          rest.nightSteps = nightSteps;
+          rest.currentNightStepIndex = Math.min(adjustedCurrentNightStepIndex, nightSteps.length);
         }
         if (Array.isArray(rest.nightStepStates)) {
           rest.nightStepStates = rest.nightStepStates.map((snapshot) => {
@@ -747,9 +780,7 @@ export const useGameStore = create<GameStore>()(
               usedGameAbilities: Array.isArray(raw.usedGameAbilities) ? raw.usedGameAbilities : [],
               enchantedPlayerIds: Array.isArray(raw.enchantedPlayerIds) ? raw.enchantedPlayerIds : [],
               infectedPlayerIds: Array.isArray(raw.infectedPlayerIds) ? raw.infectedPlayerIds : [],
-              loversIds: Array.isArray(raw.loversIds) && raw.loversIds.length === 2
-                ? raw.loversIds as [string, string]
-                : null,
+              loversIds: normalizeLoversIds(raw.loversIds),
               players: Array.isArray(raw.players) ? raw.players.map(normalizePlayer) : [],
               foxPowerActive: typeof raw.foxPowerActive === 'boolean' ? raw.foxPowerActive : true,
               wildChildModelId: typeof raw.wildChildModelId === 'string' ? raw.wildChildModelId : null,

--- a/src/styles/setup.css
+++ b/src/styles/setup.css
@@ -1,5 +1,7 @@
 /* Setup Screen */
 .setup-screen {
+  width: 100%;
+  min-width: 0;
   max-width: 760px;
   margin: 0 auto;
   padding: 1.8rem 1.1rem 4rem;
@@ -336,62 +338,6 @@
   align-self: flex-start;
 }
 
-.table-preview {
-  position: relative;
-  min-height: 360px;
-  border: 1px solid rgba(255,255,255,0.06);
-  border-radius: 14px;
-  background:
-    radial-gradient(circle at 50% 50%, rgba(185,42,58,0.12) 0 27%, transparent 28%),
-    radial-gradient(circle at 50% 50%, rgba(255,255,255,0.03) 0 46%, transparent 47%);
-  overflow: hidden;
-}
-.table-preview::before {
-  content: '';
-  position: absolute;
-  inset: 34%;
-  border-radius: 999px;
-  border: 1px solid rgba(255,255,255,0.08);
-  background: rgba(0,0,0,0.12);
-}
-.table-seat {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  width: clamp(92px, 18vw, 132px);
-  min-height: 54px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 0.2rem;
-  padding: 0.45rem 0.55rem;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: rgba(14,9,20,0.92);
-  transform:
-    translate(-50%, -50%)
-    rotate(calc(360deg / var(--seat-count) * var(--seat-index) - 90deg))
-    translateY(clamp(-140px, -28vw, -112px))
-    rotate(calc(-360deg / var(--seat-count) * var(--seat-index) + 90deg));
-  box-shadow: 0 10px 20px rgba(0,0,0,0.32);
-}
-.table-seat-number {
-  color: #f8e6d8;
-  font-weight: 800;
-  font-size: 0.78rem;
-}
-.table-seat-role {
-  color: var(--text);
-  font-size: 0.78rem;
-  font-weight: 700;
-  line-height: 1.2;
-  overflow-wrap: anywhere;
-}
-.table-seat.camp-village { border-color: rgba(46,160,67,0.5); }
-.table-seat.camp-werewolves { border-color: rgba(218,54,51,0.55); }
-.table-seat.camp-ambiguous { border-color: rgba(110,118,129,0.55); }
-.table-seat.camp-loner { border-color: rgba(147,51,234,0.55); }
-
 /* Role summary */
 .role-summary {
   display: flex;
@@ -483,13 +429,4 @@
   .role-select { width: 100%; }
   .role-slot-label { width: 100%; }
   .role-slot-actions { width: 100%; justify-content: flex-end; }
-  .table-preview { min-height: 420px; }
-  .table-seat {
-    width: 92px;
-    transform:
-      translate(-50%, -50%)
-      rotate(calc(360deg / var(--seat-count) * var(--seat-index) - 90deg))
-      translateY(-165px)
-      rotate(calc(-360deg / var(--seat-count) * var(--seat-index) + 90deg));
-  }
 }

--- a/src/types/game.types.ts
+++ b/src/types/game.types.ts
@@ -115,6 +115,7 @@ export interface GameState {
   enchantedPlayerIds: string[];          // players enchanted by Pied Piper
   infectedPlayerIds: string[];           // players infected by Infect Père (secret wolves)
   angelWon: boolean;                     // true if Angel was first Day-1 execution
+  firstDayExecutionDone: boolean;        // true after the first village execution on Day 1
   language: Language;
   nightStepStates: NightStepState[];     // checkpoints for each night step to allow back navigation
   protectorHistory: ProtectorRecord[];   // records per-night Protector targets

--- a/tests/e2e/fox-night.spec.ts
+++ b/tests/e2e/fox-night.spec.ts
@@ -57,3 +57,16 @@ test('manual fox power override skips future Fox wake-ups', async ({ page }) => 
   await expect(page.getByRole('heading', { name: /Night ends/i })).toBeVisible();
   await expect(page.getByText(/Fox wakes up/i)).toHaveCount(0);
 });
+
+test('manual fox power override is reflected in the day reminder', async ({ page }) => {
+  await setupGame(
+    page,
+    ['werewolf', 'fox', 'villager', 'villager', 'villager', 'villager']
+  );
+
+  await page.getByTestId('power-toggle-fox').uncheck();
+  await page.getByTestId('night-next').click();
+  await page.getByTestId('reveal-day').click();
+
+  await expect(page.getByTestId('day-phase')).toContainText('Fox sniffing power: LOST');
+});

--- a/tests/e2e/role-first-workflow.spec.ts
+++ b/tests/e2e/role-first-workflow.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test('role-first setup uses ordered seats, table preview, and seat labels', async ({ page }) => {
+test('role-first setup uses ordered seats and seat labels', async ({ page }) => {
   await page.goto('/');
 
   await expect(page.getByTestId('player-row-0').getByRole('textbox')).toHaveCount(0);
@@ -15,11 +15,12 @@ test('role-first setup uses ordered seats, table preview, and seat labels', asyn
   await page.getByTestId('player-row-3').getByTestId('role-select').selectOption('villager');
   await expect(page.getByTestId('player-row-4').getByTestId('role-select')).toContainText('Cupid');
 
-  await expect(page.getByTestId('table-preview')).toContainText('#1');
-  await expect(page.getByTestId('table-seat-1')).toContainText('Fox');
+  await expect(page.getByTestId('table-preview')).toHaveCount(0);
 
   await page.getByTestId('move-seat-down-1').click();
-  await expect(page.getByTestId('table-seat-2')).toContainText('Fox');
+  await expect(page.getByTestId('player-row-2').getByTestId('role-select')).toHaveValue('fox');
+  await expect(page.getByTestId('player-row-2')).toContainText('#3');
+  await expect(page.getByTestId('player-row-2')).toContainText('Fox');
 
   await page.getByTestId('add-role-slot').click();
   await expect(page.getByTestId('player-row-6')).toBeVisible();
@@ -90,4 +91,32 @@ test('role pools cap wolves at three and hide removed roles', async ({ page }) =
   await expect(page.getByTestId('setup-roles-tab')).not.toContainText('Raven');
   await expect(page.getByTestId('setup-roles-tab')).not.toContainText('Village Idiot');
   await expect(page.getByTestId('setup-roles-tab')).not.toContainText('Scapegoat');
+});
+
+test('setup validation requires villagers but accepts wolf-side special roles', async ({ page }) => {
+  await page.goto('/');
+
+  const noVillagerRoles = ['big_bad_wolf', 'fox', 'witch', 'cupid', 'protector', 'hunter'];
+  for (const [index, roleId] of noVillagerRoles.entries()) {
+    await page.getByTestId(`player-row-${index}`).getByTestId('role-select').selectOption(roleId);
+  }
+
+  await expect(page.getByTestId('start-game')).toBeDisabled();
+  await expect(page.locator('.setup-errors')).toContainText(/Villager/i);
+
+  await page.getByTestId('player-row-5').getByTestId('role-select').selectOption('villager');
+  await expect(page.getByTestId('start-game')).toBeEnabled();
+});
+
+test('special wolf-side roles still create the normal wolf wake-up', async ({ page }) => {
+  await page.goto('/');
+
+  const roles = ['big_bad_wolf', 'villager', 'villager', 'villager', 'villager', 'villager'];
+  for (const [index, roleId] of roles.entries()) {
+    await page.getByTestId(`player-row-${index}`).getByTestId('role-select').selectOption(roleId);
+  }
+
+  await page.getByTestId('start-game').click();
+
+  await expect(page.getByRole('heading', { name: /Werewolf wakes up/i })).toBeVisible();
 });

--- a/tests/e2e/white-wolf-endgame.spec.ts
+++ b/tests/e2e/white-wolf-endgame.spec.ts
@@ -81,6 +81,22 @@ test('eliminating the last pack wolf while white wolf lives does not give the vi
   await expect(page.getByTestId('day-phase')).toBeVisible();
 });
 
+test('wolves do not win while the white wolf is still alive', async ({ page }) => {
+  await setupGame(
+    page,
+    ['white_werewolf', 'werewolf', 'werewolf', 'villager', 'villager', 'villager']
+  );
+
+  await advanceToDay(page);
+  await eliminatePlayer(page, 'p3');
+  await eliminatePlayer(page, 'p4');
+  await eliminatePlayer(page, 'p5');
+
+  await expect(page.locator('.win-screen')).toHaveCount(0);
+  await expect(page.locator('.win-suggestion-screen')).toHaveCount(0);
+  await expect(page.getByTestId('day-phase')).toBeVisible();
+});
+
 test('village win is suggested before it is confirmed', async ({ page }) => {
   await setupGame(
     page,
@@ -101,6 +117,23 @@ test('village win is suggested before it is confirmed', async ({ page }) => {
 
   await expect(page.locator('.win-screen')).toHaveCount(1);
   await expect(page.getByRole('heading', { name: 'Village Wins!' })).toBeVisible();
+});
+
+test('angel win is suggested when Angel is the first Day 1 execution', async ({ page }) => {
+  await setupGame(
+    page,
+    ['angel', 'werewolf', 'villager', 'villager', 'villager', 'villager']
+  );
+
+  await advanceToDay(page);
+  await eliminatePlayer(page, 'p0');
+
+  await expect(page.locator('.win-screen')).toHaveCount(0);
+  await expect(page.getByRole('heading', { name: 'It looks like the Angel has won.' })).toBeVisible();
+  await page.getByTestId('confirm-winner').click();
+
+  await expect(page.locator('.win-screen')).toHaveCount(1);
+  await expect(page.getByRole('heading', { name: 'Angel Wins!' })).toBeVisible();
 });
 
 test('white wolf wins when it becomes the sole survivor', async ({ page }) => {


### PR DESCRIPTION
## Summary
- remove the setup table preview and keep ordered role editing only
- fix wolf-side setup validation, special wolf wake-up generation, Angel Day 1 win, Fox override status, and White Werewolf endgame gating
- harden persisted-game migration for removed roles and old night snapshots
- reduce Android backup/FileProvider exposure and bind Playwright dev server to localhost

## Verification
- npm run lint
- npm run build
- npm run test:e2e -- tests/e2e/role-first-workflow.spec.ts tests/e2e/fox-night.spec.ts tests/e2e/white-wolf-endgame.spec.ts
- npm run test:e2e